### PR TITLE
fix infinite list (`∞`) and unnecessary erroring imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 regex
 sympy
-pwn
 gitpython
 flask-cors

--- a/vyxal/array_builtins.py
+++ b/vyxal/array_builtins.py
@@ -10,13 +10,11 @@ from vyxal.utilities import *
 
 try:
     import numpy
-    import pwn
     import regex
     import sympy
 except ImportError:
     os.system("pip3 install -r requirements.txt --quiet --disable-pip-version-check")
     import numpy
-    import pwn
     import regex
     import sympy
 

--- a/vyxal/builtins.py
+++ b/vyxal/builtins.py
@@ -15,13 +15,11 @@ from vyxal.factorials import FIRST_100_FACTORIALS
 
 try:
     import numpy
-    import pwn
     import regex
     import sympy
 except:
     os.system("pip3 install -r requirements.txt --quiet --disable-pip-version-check")
     import numpy
-    import pwn
     import regex
     import sympy
 

--- a/vyxal/commands.py
+++ b/vyxal/commands.py
@@ -72,7 +72,7 @@ command_dict = {
         "rhs, lhs = pop(vy_globals.stack, 2); vy_globals.stack.append(ncr(lhs, rhs))",
         2,
     ),
-    "∞": ("vy_globals.stack.append(Generator(lambda x: x))", 0),
+    "∞": ("vy_globals.stack.append(Generator.from_index_function(lambda x: x))", 0),
     "!": ("vy_globals.stack.append(len(vy_globals.stack))", 0),
     '"': (
         "rhs, lhs = pop(vy_globals.stack, 2); vy_globals.stack.append([lhs, rhs])",

--- a/vyxal/interpreter.py
+++ b/vyxal/interpreter.py
@@ -18,13 +18,11 @@ from vyxal.parser import *
 
 try:
     import numpy
-    import pwn
     import regex
     import sympy
 except:
     os.system("pip3 install -r requirements.txt --quiet --disable-pip-version-check")
     import numpy
-    import pwn
     import regex
     import sympy
 

--- a/vyxal/utilities.py
+++ b/vyxal/utilities.py
@@ -233,6 +233,15 @@ class Generator:
 
         return out + "⟩"
 
+    def from_index_function(f):
+        @Generator
+        def _generated():
+            index = 0
+            while True:
+                yield f(index)
+                index += 1
+        return _generated
+
 
 class ShiftDirections:
     LEFT = 1


### PR DESCRIPTION
Fix #167 

`∞` was using an outdated representation of `Generator` which caused it to error upon being pushed. I have replaced the old functionality with a class function within `Generator`.

Additionally, importing `pwn` breaks because some initialization-related thing only works in the main thread, so when attempting to run any program, it will error. This import wasn't being used for anything, and removing it fixed the issue and did not introduce any errors.