### PR TITLE
Add a security policy

### DIFF
--- a/documents/protocols/contributing.md
+++ b/documents/protocols/contributing.md
@@ -38,9 +38,7 @@ In summary: provide helpful information in your issue and we'll be happy
 
 ### You found a bug that _is_ a security exploit
 
-Do **not** open an issue. We do not need trolls epicly trolling us.
-
-**TODO**: Figure out how to actually report security exploits
+Do **not** open an issue. See [the separate security policy](./security.md).
 
 ### You have a feature request
 

--- a/documents/protocols/security.md
+++ b/documents/protocols/security.md
@@ -1,0 +1,8 @@
+# Security Policy
+If you've found a serious security flaw in Vyxal, **do not open a public issue**. Instead, send an
+email to @pxeger: `vyxal_security@pxeger.com`. We will discuss privately how to handle it, hopefully
+apply a fix, and you will be honoured in the **Hall of Fame**.
+
+## Hall of Fame
+The following users have found security vulnerabilities:
+- @AMiller42 [found a bug in parsing](https://codegolf.stackexchange.com/a/231059)


### PR DESCRIPTION
To do:
- Probably add some more wording and stuff
- Decide on which email address(es) to use for this. I'd like to be on there though because I am a 1337 h4xx0r world class security expert
- Perhaps mention that trying to attack the official online interpreter is, ahem, *illegal*?