### PR TITLE
Corrected documentation for `E`

### DIFF
--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -681,7 +681,7 @@
 
 - element: "E"
   name: Two Power / Python Eval
-  description: a ** 2, or eval(a)
+  description: 2 ** a, or eval(a)
   arity: 1
   overloads:
     num: 2 ** a


### PR DESCRIPTION
where it says `a ** 2`, and it literally says two lines down `2 ** a` (and vyxal actually does `2 ** a`)