### PR TITLE
Adding relative imports

### DIFF
--- a/vyxal/__main__.py
+++ b/vyxal/__main__.py
@@ -1,4 +1,4 @@
-import vyxal.main
+import main
 import sys
 
 if len(sys.argv) > 1:
@@ -9,6 +9,6 @@ if len(sys.argv) > 1:
     if len(sys.argv) > 2:
         flags, inputs = sys.argv[2], sys.argv[3:]
 
-    vyxal.main.execute_vyxal(file_name, flags, inputs)
+    main.execute_vyxal(file_name, flags, inputs)
 else:
-    vyxal.main.repl()
+    main.repl()

--- a/vyxal/dictionary.py
+++ b/vyxal/dictionary.py
@@ -1,4 +1,4 @@
-from vyxal import encoding, helpers
+import encoding, helpers
 
 contents = """the
 The

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -10,6 +10,7 @@ import random
 import re
 import string
 import types
+import urllib
 from datetime import datetime
 from typing import Union
 
@@ -17,15 +18,15 @@ import num2words
 import numpy
 import sympy
 
-from vyxal import dictionary
-from vyxal.context import DEFAULT_CTX, Context
-from vyxal.encoding import (
+import dictionary
+from context import DEFAULT_CTX, Context
+from encoding import (
     base_27_alphabet,
     codepage_number_compress,
     codepage_string_compress,
 )
-from vyxal.helpers import *
-from vyxal.LazyList import LazyList, lazylist
+from helpers import *
+from LazyList import LazyList, lazylist
 
 currentdate = datetime.now()
 
@@ -1966,7 +1967,7 @@ def matrix_multiply(lhs, rhs, ctx):
     )
 
 
-def max_by_function(lhs, ctx):
+def max_by_function(lhs, rhs, ctx):
     """Element Þ↑
     (lst, fun) -> Maximum value of a by applying b to each element
     """

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -20,11 +20,11 @@ from sympy.parsing.sympy_parser import (
 )
 import numpy
 
-import vyxal.encoding
-from vyxal import lexer
-from vyxal.context import DEFAULT_CTX, Context
-import vyxal.dictionary
-from vyxal.LazyList import *
+import encoding
+import lexer
+from context import DEFAULT_CTX, Context
+import dictionary
+from LazyList import *
 
 NUMBER_TYPE = "number"
 SCALAR_TYPE = "scalar"
@@ -654,48 +654,48 @@ def uncompress_dict(source: str) -> str:
     while characters:
         char = characters.popleft()
         if escaped:
-            if char not in vyxal.encoding.compression:
+            if char not in encoding.compression:
                 ret += "\\"
             ret += char
             escaped = False
         elif char == "\\":
             escaped = True
-        elif char in vyxal.encoding.compression:
+        elif char in encoding.compression:
             temp_scc += char
             if len(temp_scc) == 2:
-                index = from_base_alphabet(temp_scc, vyxal.encoding.compression)
-                if index < len(vyxal.dictionary.contents):
-                    ret += vyxal.dictionary.contents[index]
+                index = from_base_alphabet(temp_scc, encoding.compression)
+                if index < len(dictionary.contents):
+                    ret += dictionary.contents[index]
                 temp_scc = ""
         else:
             if temp_scc:
-                pos = vyxal.encoding.compression.find(temp_scc)
-                if pos < len(vyxal.dictionary.small_dictionary):
-                    ret += vyxal.dictionary.small_dictionary[pos]
+                pos = encoding.compression.find(temp_scc)
+                if pos < len(dictionary.small_dictionary):
+                    ret += dictionary.small_dictionary[pos]
                 temp_scc = ""
             ret += char
 
     if temp_scc:
-        pos = vyxal.encoding.compression.find(temp_scc)
-        if pos < len(vyxal.dictionary.small_dictionary):
-            ret += vyxal.dictionary.small_dictionary[pos]
+        pos = encoding.compression.find(temp_scc)
+        if pos < len(dictionary.small_dictionary):
+            ret += dictionary.small_dictionary[pos]
 
     return ret
 
 
 def uncompress_str(string: str) -> str:
     base_10_representation = from_base_alphabet(
-        string, vyxal.encoding.codepage_string_compress
+        string, encoding.codepage_string_compress
     )
 
     actual = to_base_alphabet(
-        base_10_representation, vyxal.encoding.base_27_alphabet
+        base_10_representation, encoding.base_27_alphabet
     )
     return actual
 
 
 def uncompress_num(num: str) -> int:
-    return from_base_alphabet(num, vyxal.encoding.codepage_number_compress)
+    return from_base_alphabet(num, encoding.codepage_number_compress)
 
 
 def urlify(item: str) -> str:

--- a/vyxal/main.py
+++ b/vyxal/main.py
@@ -9,11 +9,11 @@ import types
 import traceback
 
 
-import vyxal.encoding
-from vyxal.context import Context
-from vyxal.elements import *
-from vyxal.transpile import transpile
-from vyxal.helpers import *
+import encoding
+from context import Context
+from elements import *
+from transpile import transpile
+from helpers import *
 
 THIS_FOLDER = os.path.dirname(os.path.abspath(__file__)) + "/.."
 sys.path.insert(1, THIS_FOLDER)
@@ -71,7 +71,7 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
     elif "v" in flags:  # Open file using Vyxal encoding
         with open(file_name, "rb") as f:
             code = f.read()
-            code = vyxal.encoding.vyxal_to_utf8(code)
+            code = encoding.vyxal_to_utf8(code)
     else:  # Open file using UTF-8 encoding:
         with open(file_name, "r", encoding="utf-8") as f:
             code = f.read()

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -13,7 +13,7 @@ import string
 from collections import deque
 from collections.abc import Iterable
 
-from vyxal import lexer, structure
+import lexer, structure
 
 STRUCTURE_INFORMATION = {
     # (Name, Closing character)

--- a/vyxal/structure.py
+++ b/vyxal/structure.py
@@ -4,7 +4,7 @@ See https://github.com/Vyxal/Vyxal/blob/fresh-beginnings/documents/specs/Structu
 """
 
 from typing import Union
-from vyxal.lexer import Token
+from lexer import Token
 
 Branch = Union[str, list["Structure"], list["Token"]]
 


### PR DESCRIPTION
Currently, Vyxal uses module imports - `import vyxal.elements` or whatever. This is, and will continue to be, an absolute nightmare for development as it uses the version of vyxal on pypi instead of what you're actually working on and want to test; or currently, nothing.