### PR TITLE
Remove unnecessary ctx argument to strip in P aka strip

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3130,7 +3130,7 @@ def strip(lhs, rhs, ctx):
         (NUMBER_TYPE, NUMBER_TYPE): lambda: vy_eval(
             vy_str(lhs).strip(vy_str(rhs))
         ),
-        (NUMBER_TYPE, str): lambda: vy_eval(vy_str(lhs).strip(rhs)),
+        (NUMBER_TYPE, str): lambda: vy_eval(vy_str(lhs).strip(rhs), ctx),
         (str, NUMBER_TYPE): lambda: lhs.strip(str(rhs)),
         (str, str): lambda: lhs.strip(rhs),
     }.get(ts, lambda: list_helper(lhs, rhs))()

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3128,9 +3128,9 @@ def strip(lhs, rhs, ctx):
     ts = vy_type(lhs, rhs)
     return {
         (NUMBER_TYPE, NUMBER_TYPE): lambda: vy_eval(
-            vy_str(lhs).strip(vy_str(rhs), ctx)
+            vy_str(lhs).strip(vy_str(rhs))
         ),
-        (NUMBER_TYPE, str): lambda: vy_eval(vy_str(lhs).strip(rhs), ctx),
+        (NUMBER_TYPE, str): lambda: vy_eval(vy_str(lhs).strip(rhs)),
         (str, NUMBER_TYPE): lambda: lhs.strip(str(rhs)),
         (str, str): lambda: lhs.strip(rhs),
     }.get(ts, lambda: list_helper(lhs, rhs))()


### PR DESCRIPTION
There were two extra `ctx` arguments given to `str.strip` inside `def strip()`/element `P`, this is just a trivial thing removing those. I haven't run any tests, but it probably works.