### PR TITLE
Make the stack pad with 0s if no input offline, and fix an issue with set operators

### DIFF
--- a/vyxal/context.py
+++ b/vyxal/context.py
@@ -6,6 +6,7 @@ class Context:
 
     def __init__(self):
         self.context_values = [0]
+        self.empty_input_is_zero = True
         self.default_arity = 1
         self.dictionary_compression = True
         self.ghost_variable = 0

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -730,9 +730,9 @@ def divide(lhs, rhs, ctx):
 
     ts = vy_type(lhs, rhs)
     return {
-        (NUMBER_TYPE, NUMBER_TYPE): lambda: vyxalify(
-            sympy.nsimplify(lhs / rhs)
-        ),
+        (NUMBER_TYPE, NUMBER_TYPE): lambda: 0
+        if lhs == rhs == 0
+        else vyxalify(sympy.nsimplify(lhs / rhs)),
         (NUMBER_TYPE, str): lambda: wrap(rhs, len(rhs) // lhs, ctx),
         (str, NUMBER_TYPE): lambda: wrap(lhs, len(lhs) // rhs, ctx),
         (str, str): lambda: lhs.split(rhs),
@@ -1590,7 +1590,9 @@ def integer_divide(lhs, rhs, ctx):
 
     ts = vy_type(lhs, rhs)
     return {
-        (NUMBER_TYPE, NUMBER_TYPE): lambda: lhs // rhs,
+        (NUMBER_TYPE, NUMBER_TYPE): lambda: 0
+        if lhs == rhs == 0
+        else lhs // rhs,
         (NUMBER_TYPE, str): lambda: divide(lhs, rhs, ctx=ctx)[0],
         (str, NUMBER_TYPE): lambda: divide(rhs, lhs, ctx=ctx)[0],
         (ts[0], types.FunctionType): lambda: foldl(

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3200,7 +3200,19 @@ def symmetric_difference(lhs, rhs, ctx):
     (any, any) -> set(a) ^ set(b)
     """
 
-    return LazyList(set(iterable(lhs, ctx=ctx)) ^ set(iterable(rhs, ctx=ctx)))
+    lhs = uniquify(iterable(lhs, ctx=ctx), ctx)
+    rhs = uniquify(iterable(rhs, ctx=ctx), ctx)
+
+    @lazylist
+    def gen():
+        for item in lhs:
+            if item not in rhs:
+                yield item
+        for item in rhs:
+            if item not in lhs:
+                yield item
+
+    return gen()
 
 
 def tail(lhs, ctx):
@@ -3367,7 +3379,19 @@ def union(lhs, rhs, ctx):
     (any, any) -> union of lhs and rhs
     """
 
-    return LazyList(set(iterable(lhs, ctx=ctx)) | set(iterable(rhs, ctx=ctx)))
+    @lazylist
+    def gen():
+        seen = []
+        for item in iterable(lhs, ctx=ctx):
+            if item not in seen:
+                yield item
+                seen.append(item)
+        for item in iterable(rhs, ctx=ctx):
+            if item not in seen:
+                yield item
+                seen.append(item)
+
+    return gen()
 
 
 def uniquify(lhs, ctx):

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -206,7 +206,9 @@ def get_input(ctx: Context) -> Any:
         else:
             try:
                 temp = vy_eval(input("> " * ctx.repl_mode), ctx)
-            except EOFError:
+                if ctx.empty_input_is_zero and temp == "":
+                    return 0
+            except Exception:
                 temp = 0
             return temp
     else:

--- a/vyxal/main.py
+++ b/vyxal/main.py
@@ -87,8 +87,6 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
     else:
         inputs = list(map(lambda x: vy_eval(x, ctx), inputs))
 
-    print(inputs)
-
     if "a" in flags:  # All inputs as array
         inputs = [inputs]
 
@@ -114,11 +112,12 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
 
     ctx.reverse_flag = "r" in flags
     ctx.number_as_range = "R" in flags
-    ctx.dictionary_compression = not "D" in flags
+    ctx.dictionary_compression = "D" not in flags
     ctx.variable_length_1 = "V" in flags
     ctx.truthy_lists = "t" in flags  # L431 in elements.py
-    ctx.vyxal_lists = not "P" in flags
+    ctx.vyxal_lists = "P" not in flags
     ctx.print_decimals = "ḋ" in flags
+    ctx.empty_input_is_zero = "?" not in flags
 
     if "2" in flags:
         ctx.default_arity = 2


### PR DESCRIPTION
Closes #304 
Closes #352 

I also fixed a little division by 0 error I noticed - it's just implementing the behaviour that already exists in 2.4 and has proven to be useful: `0 / 0 = 0` for golfing purposes.