### PR TITLE
Hide generated elements files from GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+documents/knowledge/elements.md linguist-generated=true
+documents/knowledge/Elements.txt linguist-generated=true
+static/parsed_yaml.js linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 documents/knowledge/elements.md linguist-generated=true
 documents/knowledge/Elements.txt linguist-generated=true
 static/parsed_yaml.js linguist-generated=true
+tests/test_elements.py linguist-generated=true


### PR DESCRIPTION
Whenever `elements.yaml` changes, I always see `Elements.txt` first and comment on that before realising it's not the source file. By marking these files as `linguist-generated=true` in a `.gitattributes` file, they will be excluded from GitHub diffs, and this won't happen.

See https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github