### PR TITLE
Add eval as JS option

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -206,6 +206,13 @@ $(document).ready(e => {
                 footer: e_footer.doc.getValue(),
                 header: e_header.doc.getValue()
             }, res => {
+                if (flags.value.includes('E')) {
+                    alert('Please read and ensure you 100% trust the JavaScript code which is about to be evaluated. The code is (see next alert):')
+                    alert(res.stdout)
+                    if (confirm('Do you want to execute it? If you are remotely unsure, click Cancel!')) {
+                        res.stdout = new Function(res.stdout)()
+                    }
+                }
                 output.value = res.stdout
                 extra.value = res.stderr
                 run.innerHTML =


### PR DESCRIPTION
Closes #407.

Hopefully this series of popups is good enough to prevent self-XSS.