### PR TITLE
Fix deepcover PYL-R1714 issues

### DIFF
--- a/vyxal/transpile.py
+++ b/vyxal/transpile.py
@@ -444,9 +444,9 @@ def transpile_structure(
     if isinstance(struct, vyxal.structure.RecurseStatement):
         if struct.parent_structure == vyxal.structure.IfStatement:
             return indent_str("pass", indent)
-        elif (
-            struct.parent_structure == vyxal.structure.ForLoop
-            or struct.parent_structure == vyxal.structure.WhileLoop
+        elif struct.parent_structure in (
+            vyxal.structure.ForLoop,
+            vyxal.structure.WhileLoop,
         ):
             return indent_str("continue", indent)
         elif struct.parent_structure == vyxal.structure.FunctionDef:
@@ -455,10 +455,10 @@ def transpile_structure(
             )
         elif struct.parent_structure == vyxal.structure.Lambda:
             return indent_str("stack += this(stack, this, ctx=ctx)", indent)
-        elif (
-            struct.parent_structure == vyxal.structure.MonadicModifier
-            or struct.parent_structure == vyxal.structure.DyadicModifier
-            or struct.parent_structure == vyxal.structure.TriadicModifier
+        elif struct.parent_structure in (
+            vyxal.structure.MonadicModifier,
+            vyxal.structure.DyadicModifier,
+            vyxal.structure.TriadicModifier,
         ):
             return indent_str(
                 "stack += ctx.function_stack[-2](stack, ctx.function_stack[-2],"


### PR DESCRIPTION
To check if a variable is equal to one of many values, combine the values into a tuple and check if the variable is contained `in` it instead of checking for equality against each of the values. This is faster, less verbose, and more readable.

