### PR TITLE
Rename step in testing workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ on:
     branches-ignore: [ production ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It was called `build` which was kinda confusing; now it's called `test`