### PR TITLE
Make cartesian product over list (Þ*)

### DIFF
--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4140,6 +4140,17 @@
     num: to_decimal(a)
   vectorise: false
 
+- element: "Þ*"
+  name: Cartesian product over list
+  description: Cartesian product over a list of lists
+  arity: 1
+  overloads:
+    lst: itertools.product(*a)
+  vectorise: false
+  tests:
+    - "[[[1, 2], [3], [4, 5]]] : [[1, 3, 4], [1, 3, 5], [2, 3, 4], [2, 3, 5]]"
+    - "[[[1, 2], [3, 4], []]] : []"
+
 - element: "Þo"
   name: Ordinals
   description: An infinite list of first, second, third, fourth etc

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -17823,6 +17823,50 @@ def test_StringPartitions():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx)
 
 
+def test_Cartesianproductoverlist():
+
+    stack = [vyxalify(item) for item in [[[1, 2], [3], [4, 5]]]]
+    expected = vyxalify([[1, 3, 4], [1, 3, 5], [2, 3, 4], [2, 3, 5]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þ*')
+    # print('Þ*', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx)
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx)
+
+
+    stack = [vyxalify(item) for item in [[[1, 2], [3, 4], []]]]
+    expected = vyxalify([])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þ*')
+    # print('Þ*', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx)
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx)
+
+
 def test_AllUnique():
 
     stack = [vyxalify(item) for item in ["hello"]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -480,6 +480,15 @@ def carmichael_function(lhs, ctx):
     }.get(ts, lambda: vectorise(carmichael_function, lhs, ctx=ctx))()
 
 
+def cartesian_over_list(lhs, ctx):
+    """Element Þ*
+    (lst) -> itertools.product(*lhs)
+    """
+    # todo maybe handle generators separately
+    lhs = [iterable(elem, ctx=ctx) for elem in iterable(lhs, ctx=ctx)]
+    return vyxalify(itertools.product(*lhs))
+
+
 def cartesian_power(lhs, rhs, ctx):
     """Element ÞẊ
     (any, num) -> cartesian_power(a, b)
@@ -4609,6 +4618,7 @@ elements: dict[str, tuple[str, int]] = {
     "øV": process_element(replace_until_no_change, 3),
     "øF": process_element(factorial_of_range, 1),
     "øṙ": process_element(regex_sub, 3),
+    "Þ*": process_element(cartesian_over_list, 1),
     "Þo": process_element(infinite_ordinals, 0),
     "Þc": process_element(infinite_cardinals, 0),
     "Þp": process_element(infinite_primes, 0),


### PR DESCRIPTION
This PR adds `Þ*` as a digraph to do cartesian product over a list like Jelly (note that this isn't the same as reducing with cartesian product, so a new digraph was necessary). The actual symbol used for the digraph can of course be changed, this PR is really just to implement it. It doesn't handle generators because cartesian product over a possibly infinite list of possibly infinite lists is gonna be really complicated.

Closes #446 