### PR TITLE
Add GitHub actions workflow to build and publish package to PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip poetry
+          poetry install
+      - name: Build
+        run: poetry build
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PXEGER_TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
You will soon be able to do `pip install vyxal` with no further details. Closes https://github.com/attempt-this-online/attempt-this-online/issues/6 (CC @Lyxal)

This needs to be pulled into `main`, tested with a placeholder tag (I suggest `v2.7.2post1`), and if/when it works:
1. remove the `repository_url` so it uses the real PyPI
2. replace the PyPI token with one that has permission to upload to the `vyxal` package namespace
  - I suggest I own that package initially and then once I've got it all working I'll grant permissions to people (you'll need PyPI accounts!)