### PR TITLE
Remove a few badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vyxal
 
-[![forthebadge](https://forthebadge.com/images/badges/gluten-free.svg)](https://forthebadge.com) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/Vyxal/Vyxal.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Vyxal/Vyxal/context:python) [![Total alerts](https://img.shields.io/lgtm/alerts/g/Vyxal/Vyxal.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Vyxal/Vyxal/alerts/) ![Deploy status](https://github.com/Vyxal/Vyxal/actions/workflows/deploy.yaml/badge.svg) ![Test status](https://github.com/Vyxal/Vyxal/actions/workflows/run-tests.yaml/badge.svg) ![Linter status](https://github.com/Vyxal/Vyxal/actions/workflows/linter.yaml/badge.svg)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/Vyxal/Vyxal.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/Vyxal/Vyxal/context:python) ![Test status](https://github.com/Vyxal/Vyxal/actions/workflows/run-tests.yaml/badge.svg)
 
 Vyxal is a golfing language with a unique design philosophy: make things as short as possible but retain elegance while doing so. In very simple terms, this means
 keeping aspects of traditional programming languages that most developers are familiar with, while still providing commands that allow golfers to actually _win_


### PR DESCRIPTION
This will keep only the lgtm code quality badge (because it looks nice if we have A quality code) and the tests badge (because it's important for our code to run). PA deployment can be seen on the right in the Environments section, I think. We're not gluten free anymore because of sympy, and we don't want people seeing how many LGTM alerts we have.