### PR TITLE
Vectorised printing should no longer be an issue

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3702,7 +3702,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             ret = simple.get(ts)()
 
-        if function.force_eval:
+        if "force_eval" in dir(function) and function.force_eval:
             return list(ret)
         else:
             return LazyList(ret)
@@ -3745,7 +3745,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             ret = simple.get(ts)
 
-        if function.force_eval:
+        if "force_eval" in dir(function) and function.force_eval:
             return list(ret())
         else:
             return LazyList(ret())
@@ -3756,7 +3756,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             lhs = iterable(lhs, ctx=ctx)
         ret = (safe_apply(function, x, ctx=ctx) for x in lhs)
-        if function.force_eval:
+        if "force_eval" in dir(function) and function.force_eval:
             return list(ret)
         return LazyList(ret)
 

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -31,6 +31,8 @@ from vyxal.LazyList import LazyList, lazylist
 NUMBER_TYPE = "number"
 SCALAR_TYPE = "scalar"
 
+FORCE_EVAL = "force_eval"
+
 EPSILON = 1e-10
 
 
@@ -3159,7 +3161,7 @@ def sort_by(lhs, rhs, ctx):
         )
         ret = sorted(vector, key=lambda x: safe_apply(function, x, ctx=ctx))
 
-        if "force_eval" in dir(function) and function.force_eval:
+        if FORCE_EVAL in dir(function) and function.force_eval:
             return list(ret)
         else:
             return LazyList(ret)
@@ -3702,7 +3704,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             ret = simple.get(ts)()
 
-        if "force_eval" in dir(function) and function.force_eval:
+        if FORCE_EVAL in dir(function) and function.force_eval:
             return list(ret)
         else:
             return LazyList(ret)
@@ -3745,7 +3747,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             ret = simple.get(ts)
 
-        if "force_eval" in dir(function) and function.force_eval:
+        if FORCE_EVAL in dir(function) and function.force_eval:
             return list(ret())
         else:
             return LazyList(ret())
@@ -3756,7 +3758,7 @@ def vectorise(function, lhs, rhs=None, other=None, explicit=False, ctx=None):
         else:
             lhs = iterable(lhs, ctx=ctx)
         ret = (safe_apply(function, x, ctx=ctx) for x in lhs)
-        if "force_eval" in dir(function) and function.force_eval:
+        if FORCE_EVAL in dir(function) and function.force_eval:
             return list(ret)
         return LazyList(ret)
 
@@ -3913,7 +3915,7 @@ def vy_filter(lhs: Any, rhs: Any, ctx):
             lambda x: safe_apply(lhs, x, ctx=ctx),
             iterable(rhs, range, ctx=ctx),
         )
-        if "force_eval" in dir(lhs) and lhs.force_eval:
+        if FORCE_EVAL in dir(lhs) and lhs.force_eval:
             return list(ret)
         return LazyList(ret)
 
@@ -4008,7 +4010,7 @@ def vy_map(lhs, rhs, ctx):
         for element in itr:
             yield safe_apply(function, element, ctx=ctx)
 
-    if "force_eval" in dir(function) and function.force_eval:
+    if FORCE_EVAL in dir(function) and function.force_eval:
         return list(gen())
     return gen()
 

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3159,7 +3159,7 @@ def sort_by(lhs, rhs, ctx):
         )
         ret = sorted(vector, key=lambda x: safe_apply(function, x, ctx=ctx))
 
-        if function.force_eval:
+        if "force_eval" in dir(function) and function.force_eval:
             return list(ret)
         else:
             return LazyList(ret)
@@ -3913,7 +3913,7 @@ def vy_filter(lhs: Any, rhs: Any, ctx):
             lambda x: safe_apply(lhs, x, ctx=ctx),
             iterable(rhs, range, ctx=ctx),
         )
-        if lhs.force_eval:
+        if "force_eval" in dir(lhs) and lhs.force_eval:
             return list(ret)
         return LazyList(ret)
 
@@ -4008,7 +4008,7 @@ def vy_map(lhs, rhs, ctx):
         for element in itr:
             yield safe_apply(function, element, ctx=ctx)
 
-    if function.force_eval:
+    if "force_eval" in dir(function) and function.force_eval:
         return list(gen())
     return gen()
 

--- a/vyxal/structure.py
+++ b/vyxal/structure.py
@@ -173,9 +173,13 @@ def can_print(structures: list[Structure]) -> bool:
         else:
             for branch in struct.branches:
                 if isinstance(branch, (Structure)):
-                    branch = [branch]
+                    branch = [branch]  # Wrap singleton structures into a
+                    # list so they can just be plugged
+                    # into can_print
                 if isinstance(branch, (list, tuple)):
                     if can_print(branch):
                         return True
+            # These if statements exist because sometimes, a structure
+            # has non-structure stuff in its branches.
 
     return False

--- a/vyxal/structure.py
+++ b/vyxal/structure.py
@@ -9,6 +9,8 @@ from vyxal.lexer import Token
 
 Branch = Union[str, list["Structure"], list["Token"]]
 
+PRINTING_ELEMENTS = list(",₴…") + ["¨,", "¨…"]
+
 
 class Structure:
     def __init__(self, *branches: Branch):
@@ -168,7 +170,7 @@ def can_print(structures: list[Structure]) -> bool:
             continue  # These statements can't possibly print, so it's
             # okay to just continue.
         elif isinstance(struct, GenericStatement):
-            if struct.branches[0][0].value in list(",₴…") + ["¨,", "¨…"]:
+            if struct.branches[0][0].value in PRINTING_ELEMENTS:
                 return True
         else:
             for branch in struct.branches:

--- a/vyxal/transpile.py
+++ b/vyxal/transpile.py
@@ -282,6 +282,7 @@ def transpile_structure(
             + indent_str("ctx.inputs.pop()", indent + 1)
             + indent_str("ctx.stacks.pop()", indent + 1)
             + indent_str("return stack", indent + 1)
+            + indent_str(f"VAR_{var}.force_eval = {struct.force_eval}", indent)
         )
     if isinstance(struct, vyxal.structure.Lambda):
         id_ = secrets.token_hex(16)
@@ -346,6 +347,9 @@ def transpile_structure(
                     else "ctx.default_arity"
                 ),
                 indent,
+            )
+            + indent_str(
+                f"_lambda_{id_}.force_eval = {struct.force_eval}", indent
             )
             + indent_str(f"stack.append(_lambda_{id_})", indent)
         )


### PR DESCRIPTION
Closes #336 

Consider something like:

```
₁ƛ₍₃₅kF½*∑∴,
```

Usually, that prints an ugly mess of list syntax:

```
⟨ 1
12
 | 2Fizz
 | 34
 | 4Buzz
 | 5Fizz
 | 67
 | 78
 | 8Fizz...
```

This PR fixes that by making it so that functions can tell if there's a possibility they might print, and if so, force eager evaluation in situations where lazy evaluation wouldn't work.