### PR TITLE
Add øṁ to elements dict, add test for it

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -2918,7 +2918,7 @@ Vertical mirror, and swap brackets and slashes in the second half.
 
 ### Overloads
 
-- any a: `vertical_mirror(a,mapping  = flip brackets and slashes)`
+- any a: `vertical_mirror(a, mapping = flip brackets and slashes)`
 -------------------------------
 ## `` øṖ `` (String Partitions)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -2540,7 +2540,7 @@ kṘ (Roman Numerals)
 
 - Vertical mirror, and swap brackets and slashes in the second half.
 
-    any a: vertical_mirror(a,mapping  = flip brackets and slashes)
+    any a: vertical_mirror(a, mapping = flip brackets and slashes)
 -------------------------------
 øṖ (String Partitions)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4117,13 +4117,15 @@
   overloads:
     str: vertical_mirror(a)
   vectorise: true
+  tests:
+    - '["abc"] : "abccba"'
 
 - element: "øṀ"
   name: Flip Brackets Vertical Mirror
   description: Vertical mirror, and swap brackets and slashes in the second half.
   arity: 1
   overloads:
-    any: vertical_mirror(a,mapping  = flip brackets and slashes)
+    any: vertical_mirror(a, mapping = flip brackets and slashes)
   vectorise: false
   tests:
     - '["[}"] : "[}{]"'

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2034,7 +2034,7 @@ str a -> vertical_mirror(a)
 codepage_descriptions[193] += `
 øṀ (Flip Brackets Vertical Mirror)
 Vertical mirror, and swap brackets and slashes in the second half.
-any a -> vertical_mirror(a,mapping  = flip brackets and slashes)
+any a -> vertical_mirror(a, mapping = flip brackets and slashes)
 `
 codepage_descriptions[196] += `
 øṖ (String Partitions)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1,0 +1,48 @@
+"""
+This file is for testing specific elements that can't go in elements.yaml
+"""
+
+import os
+import sys
+import sympy
+
+THIS_FOLDER = os.path.dirname(os.path.abspath(__file__)) + "/.."
+sys.path.insert(1, THIS_FOLDER)
+
+from vyxal.transpile import *
+from vyxal.elements import *
+from vyxal.context import Context
+from vyxal.helpers import *
+from vyxal.LazyList import *
+
+
+def run_vyxal(vy_code, inputs=[]):
+    stack = list(map(vyxalify, inputs))
+    ctx = Context()
+    ctx.stacks.append(stack)
+
+    py_code = transpile(vy_code)
+    exec(py_code)
+
+    ctx.stacks.pop()
+    return stack
+
+
+def test_vertical_mirror():
+    """Test øṁ"""
+    # Join these on newlines into one string and check if the result
+    # is as expected
+    tests = [
+        ("abc", "abccba"),
+        ("aj38asd#f|", "aj38asd#f||f#dsa83ja"),
+        ("ಠ_ಠ¯\\_(ツ)_/¯", "ಠ_ಠ¯\\_(ツ)_/¯¯/_)ツ(_\\¯ಠ_ಠ"),
+        ("><>", "><>><>"),
+    ]
+
+    input_str = "\n".join(test[0] for test in tests)
+    expected = "\n".join(test[1] for test in tests)
+
+    stack = run_vyxal("øṁ", [input_str])
+
+    actual = stack[-1]
+    assert actual == expected

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -17758,6 +17758,29 @@ def test_PluraliseCount():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx)
 
 
+def test_VerticalMirror():
+
+    stack = [vyxalify(item) for item in ["abc"]]
+    expected = vyxalify("abccba")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('øṁ')
+    # print('øṁ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx)
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx)
+
+
 def test_FlipBracketsVerticalMirror():
 
     stack = [vyxalify(item) for item in ["[}"]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -1119,7 +1119,7 @@ def flatten_by(lhs, rhs, ctx):
 
 def flip_brackets_vertical_mirror(lhs, ctx):
     """Element øṀ
-    (str) -> vertical_mirror(a,mapping  = flip brackets and slashes)
+    (str) -> vertical_mirror(a, mapping = flip brackets and slashes)
     """
     result = lhs.split("\n")
     for i in range(len(result)):
@@ -4684,6 +4684,7 @@ elements: dict[str, tuple[str, int]] = {
     "ø↲": process_element(custom_pad_left, 3),
     "ø↳": process_element(custom_pad_right, 3),
     "øM": process_element(flip_brackets_vertical_palindromise, 1),
+    "øṁ": process_element(vertical_mirror, 1),
     "øṀ": process_element(flip_brackets_vertical_mirror, 1),
     "øW": process_element(group_on_words, 1),
     "øP": process_element(pluralise_count, 2),


### PR DESCRIPTION
For some reason, `øṁ` wasn't actually in the dictionary even though it was implemented.