### PR TITLE
Handle desugaring of lambdas in transpiler instead of parser

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -66,3 +66,9 @@ def test_cumulative_reduce():
 
     stack = run_vyxal("34212 ɖ-")
     assert stack[-1] == [3, -1, -3, -4, -6]
+
+
+def test_map_lambda_as_element():
+    """Test that a map lambda is held as a single element"""
+    stack = run_vyxal("⁽ƛ1+;M", inputs=[[[1, 2], [3, 4]]])
+    assert stack[-1] == [[2, 3], [4, 5]]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -46,8 +46,7 @@ def test_fizzbuzz():
     assert str(fully_parse("₁ƛ₍₃₅kF½*∑∴")) == str(
         [
             GenericStatement([Token(TokenType.GENERAL, "₁")]),
-            Lambda(
-                "1",
+            LambdaMap(
                 [
                     DyadicModifier(
                         "₍",
@@ -59,9 +58,8 @@ def test_fizzbuzz():
                     GenericStatement([Token(TokenType.GENERAL, "*")]),
                     GenericStatement([Token(TokenType.GENERAL, "∑")]),
                     GenericStatement([Token(TokenType.GENERAL, "∴")]),
-                ],
+                ]
             ),
-            GenericStatement([Token(TokenType.GENERAL, "M")]),
         ]
     )
 

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -182,36 +182,18 @@ def parse(
 
             elif structure_cls == structure.LambdaMap:
                 structures.append(
-                    structure.Lambda(1, parse(branches[0], structure_cls))
+                    structure.LambdaMap(parse(branches[0], structure_cls))
                 )
-                structures.append(
-                    structure.GenericStatement(
-                        [lexer.Token(lexer.TokenType.GENERAL, "M")]
-                    )
-                )
-                # laziness ftw
 
             elif structure_cls == structure.LambdaFilter:
                 structures.append(
-                    structure.Lambda(1, parse(branches[0], structure_cls))
+                    structure.LambdaFilter(parse(branches[0], structure_cls))
                 )
-                structures.append(
-                    structure.GenericStatement(
-                        [lexer.Token(lexer.TokenType.GENERAL, "F")]
-                    )
-                )
-                # laziness ftw
 
             elif structure_cls == structure.LambdaSort:
                 structures.append(
-                    structure.Lambda(1, parse(branches[0], structure_cls))
+                    structure.LambdaSort(parse(branches[0], structure_cls))
                 )
-                structures.append(
-                    structure.GenericStatement(
-                        [lexer.Token(lexer.TokenType.GENERAL, "ṡ")]
-                    )
-                )
-                # laziness ftw
 
             else:
                 branches = list(

--- a/vyxal/structure.py
+++ b/vyxal/structure.py
@@ -3,7 +3,7 @@
 See https://github.com/Vyxal/Vyxal/blob/fresh-beginnings/documents/specs/Structures.md
 """
 
-from typing import Union
+from typing import Optional, Union
 
 from vyxal.lexer import Token
 
@@ -80,25 +80,30 @@ class FunctionDef(Structure):
 
 
 class Lambda(Structure):
-    def __init__(self, arity: int, body: list[Structure]):
+    def __init__(
+        self, arity: int, body: list[Structure], after: Optional[str] = None
+    ):
+        """`after` is for map, filter, and sort lambdas, to execute an
+        element after the lambda is pushed onto the stack"""
         super().__init__(str(arity), body)
         self.arity = arity
         self.body = body
+        self.after = after
 
 
 class LambdaMap(Lambda):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body)
+        super().__init__(1, body, after="M")
 
 
 class LambdaFilter(Lambda):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body)
+        super().__init__(1, body, after="F")
 
 
 class LambdaSort(Lambda):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body)
+        super().__init__(1, body, after="ṡ")
 
 
 class ListLiteral(Structure):


### PR DESCRIPTION
Instead of immediately splitting map, filter, and sort lambdas into two elements (the lambda and the operation after it), this adds a field `after` to the `Lambda` class itself that will contain an element to be run after the lambda (or be `None` if it's a normal lambda). Then, in the transpilation phase, a call to the `after` element is added for those three special lambdas. This allows stuff like `⁽ƛ....;` to work, because previously, the lambda and the call to `M` were held as separate elements.