### PR TITLE
Separate map/filter/sort lambdas from normal lambdas

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -75,7 +75,8 @@ def test_map_lambda_as_element():
     stack = run_vyxal("⁽ƛ1+;M", inputs=[[[1, 2], [3, 4]]])
     assert stack[-1] == [[2, 3], [4, 5]]
 
+
 def test_vectorise_map_lambda():
     """Test that a map lambda can be vectorised"""
-    stack = run_vyxal("vƛ30∴;", inputs=[[[34,1324,23],[45,3]]])
-    assert simplify(stack[-1]) == [[34,1324,30],[45,30]]
+    stack = run_vyxal("vƛ30∴;", inputs=[[[34, 1324, 23], [45, 3]]])
+    assert simplify(stack[-1]) == [[34, 1324, 30], [45, 30]]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -16,12 +16,14 @@ from vyxal.helpers import *
 from vyxal.LazyList import *
 
 
-def run_vyxal(vy_code, inputs=[]):
+def run_vyxal(vy_code, inputs=[], *, debug=False):
     stack = list(map(vyxalify, inputs))
     ctx = Context()
     ctx.stacks.append(stack)
 
     py_code = transpile(vy_code)
+    if debug:
+        print(py_code)
     exec(py_code)
 
     ctx.stacks.pop()
@@ -72,3 +74,8 @@ def test_map_lambda_as_element():
     """Test that a map lambda is held as a single element"""
     stack = run_vyxal("⁽ƛ1+;M", inputs=[[[1, 2], [3, 4]]])
     assert stack[-1] == [[2, 3], [4, 5]]
+
+def test_vectorise_map_lambda():
+    """Test that a map lambda can be vectorised"""
+    stack = run_vyxal("vƛ30∴;", inputs=[[[34,1324,23],[45,3]]])
+    assert simplify(stack[-1]) == [[34,1324,30],[45,30]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -13,7 +13,7 @@ import string
 import types
 import urllib
 from datetime import datetime
-from typing import Union
+from typing import Callable, Union
 
 import num2words
 import sympy
@@ -35,7 +35,7 @@ EPSILON = 1e-10
 
 
 def process_element(
-    expr: Union[str, types.FunctionType], arity: int
+    expr: Union[str, Callable[..., Any]], arity: int
 ) -> tuple[str, int]:
     """Take a python expression and adds boilerplate for element functions to it
 
@@ -47,7 +47,7 @@ def process_element(
     if arity:
         arguments = ["third", "rhs", "lhs"][-arity:]
     else:
-        arguments = "_"
+        arguments = ["_"]
     if isinstance(expr, types.FunctionType):
         pushed = f"{expr.__name__}({', '.join(arguments[::-1])}, ctx=ctx)"
     else:

--- a/vyxal/encoding.py
+++ b/vyxal/encoding.py
@@ -30,8 +30,8 @@ def vyxal_to_utf8(code: list[int]) -> str:
     return processed_code
 
 
-def utf8_to_vyxal(code: str) -> list[int]:
-    """Turn UTF-8 characters into integers on the Vyxal codepage"""
+def utf8_to_vyxal(code: str) -> str:
+    """Turn UTF-8 characters into bytes according to the codepage"""
     # Taken from the old 05AB1E interpreter
     processed_code = ""
     for char in code:

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -863,7 +863,9 @@ def wrap_with_width(vector: Union[str, list], width: int) -> list[Any]:
     return ret
 
 
-def wrapify(item: Any, count: int = None, ctx: Context = DEFAULT_CTX) -> List[Any]:
+def wrapify(
+    item: Any, count: int = None, ctx: Context = DEFAULT_CTX
+) -> List[Any]:
     """Leaves lists as lists, wraps scalars into a list"""
     if count is not None:
         temp = pop(item, count, ctx)

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -11,7 +11,7 @@ import itertools
 import math  # lgtm [py/unused-import]
 import textwrap
 import types
-from typing import Any, List, Union
+from typing import Any, Iterable, List, Union
 
 import sympy
 from sympy.parsing.sympy_parser import (
@@ -56,7 +56,7 @@ def collect_until_false(
         val = safe_apply(function, val, ctx=ctx)
 
 
-def concat(vec1: VyList, vec2: VyList, ctx: Context = None) -> VyList:
+def concat(vec1: VyList, vec2: VyList, ctx: Context = DEFAULT_CTX) -> VyList:
     """Concatenate two lists/lazylists"""
     if LazyList not in (type(vec1), type(vec2)):
         return vec1 + vec2
@@ -280,7 +280,7 @@ def levenshtein_distance(s1: str, s2: str) -> int:
     if len(s1) > len(s2):
         s1, s2 = s2, s1
 
-    distances = range(len(s1) + 1)
+    distances: Iterable[int] = range(len(s1) + 1)
     for i2, c2 in enumerate(s2):
         distances_ = [i2 + 1]
         for i1, c1 in enumerate(s1):
@@ -646,6 +646,8 @@ def simplify(value: Any) -> Union[int, float, str, list]:
         return value
     elif is_sympy(value):
         return eval(sympy.pycode(value))
+    elif isinstance(value, types.FunctionType):
+        return str(value)
     else:
         return [simplify(x) for x in value]
 
@@ -706,7 +708,7 @@ def transfer_capitalisation(source: str, target: str) -> str:
 
 
 def transpose(
-    vector: VyList, filler: Any = None, ctx: Context = None
+    vector: VyList, filler: Any = None, ctx: Context = DEFAULT_CTX
 ) -> VyList:
     """Transposes a vector"""
     vector = iterable(vector, ctx=ctx)
@@ -840,9 +842,9 @@ def vyxalify(value: Any) -> Any:
         return LazyList(map(vyxalify, value))
 
 
-def wrap_with_width(vector: Union[str, list], width: int) -> List[Any]:
+def wrap_with_width(vector: Union[str, list], width: int) -> list[Any]:
     """A version of textwrap.wrap that plays nice with spaces"""
-    ret = []
+    ret: list[Union[str, list]] = []
     temp = []
     for item in vector:
         temp.append(item)
@@ -861,7 +863,7 @@ def wrap_with_width(vector: Union[str, list], width: int) -> List[Any]:
     return ret
 
 
-def wrapify(item: Any, count: int = None, ctx: Context = None) -> List[Any]:
+def wrapify(item: Any, count: int = None, ctx: Context = DEFAULT_CTX) -> List[Any]:
     """Leaves lists as lists, wraps scalars into a list"""
     if count is not None:
         temp = pop(item, count, ctx)

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -12,6 +12,7 @@ import re
 import string
 from collections import deque
 from collections.abc import Iterable
+from typing import Optional
 
 from vyxal import lexer, structure
 
@@ -78,10 +79,10 @@ def variable_name(tokens: list[lexer.Token]) -> str:
 
 
 def parse(
-    token_list: Iterable[lexer.Token], parent: structure.Structure = None
+    token_list: Iterable[lexer.Token], parent: Optional[type] = None
 ) -> list[structure.Structure]:
     """Main parse function: transforms a list of Tokens into a list of Structures."""
-    structures = []
+    structures: list[structure.Structure] = []
     bracket_stack = []  # all currently open structures
     tokens = deque(token_list)
     branches: list[structure.Branch] = []  # This will serve as a way

--- a/vyxal/structure.py
+++ b/vyxal/structure.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 from vyxal.lexer import Token
 
-Branch = Union[str, list["Structure"], list["Token"]]
+Branch = Union[str, "Structure", list["Structure"], list["Token"]]
 
 
 class Structure:
@@ -80,30 +80,34 @@ class FunctionDef(Structure):
 
 
 class Lambda(Structure):
-    def __init__(
-        self, arity: int, body: list[Structure], after: Optional[str] = None
-    ):
-        """`after` is for map, filter, and sort lambdas, to execute an
-        element after the lambda is pushed onto the stack"""
+    def __init__(self, arity: int, body: list[Structure]):
         super().__init__(str(arity), body)
         self.arity = arity
         self.body = body
+
+
+class LambdaOp(Structure):
+    """A lambda followed by a monad"""
+
+    def __init__(self, body: list[Structure], after: str):
+        super().__init__(body, after)
+        self.lam = Lambda(1, body)
         self.after = after
 
 
-class LambdaMap(Lambda):
+class LambdaMap(LambdaOp):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body, after="M")
+        super().__init__(body, after="M")
 
 
-class LambdaFilter(Lambda):
+class LambdaFilter(LambdaOp):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body, after="F")
+        super().__init__(body, after="F")
 
 
-class LambdaSort(Lambda):
+class LambdaSort(LambdaOp):
     def __init__(self, body: list[Structure]):
-        super().__init__(1, body, after="ṡ")
+        super().__init__(body, after="ṡ")
 
 
 class ListLiteral(Structure):

--- a/vyxal/transpile.py
+++ b/vyxal/transpile.py
@@ -287,6 +287,14 @@ def transpile_structure(
         )
     if isinstance(struct, vyxal.structure.Lambda):
         return transpile_lambda(struct, indent, dict_compress=dict_compress)
+    if isinstance(struct, vyxal.structure.LambdaOp):
+        return transpile_lambda(
+            struct.lam, indent, dict_compress=dict_compress
+        ) + transpile_token(
+            Token(TokenType.GENERAL, struct.after),
+            indent,
+            dict_compress=dict_compress,
+        )
 
     if isinstance(struct, vyxal.structure.ListLiteral):
         # We have to manually build this because we don't know how
@@ -433,7 +441,7 @@ def transpile_lambda(
     # other, meaning int(time.time()) would return the exact same
     # lambda name for multiple lambdas.
 
-    transpiled = (
+    return (
         indent_str(
             f"def _lambda_{id_}(arg_stack, self, arity=-1, ctx=None):",
             indent,
@@ -490,12 +498,3 @@ def transpile_lambda(
         )
         + indent_str(f"stack.append(_lambda_{id_})", indent)
     )
-    if lam.after:
-        after = transpile_token(
-            Token(TokenType.GENERAL, lam.after),
-            indent,
-            dict_compress=dict_compress,
-        )
-        transpiled += "\n" + after
-
-    return transpiled


### PR DESCRIPTION
My "fix" for map lambdas not being taken as single elements earlier actually broke this. Now I've made a `LambdaOp` class that's separate from the `Lambda` class. Let's hope it works properly now.

Also, mypy found over a hundred errors :(.