### PR TITLE
Add comparisons for lazylists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -97,16 +97,20 @@ def test_beheading_infinite_lists():
     stack = run_vyxal("⁽› 1 Ḟ Ḣ")
     assert stack[-1][0:5] == [2, 3, 4, 5, 6]
 
+
 def test_equal_lazylists():
     assert LazyList(range(10)) == LazyList(range(10))
+
 
 def test_lessthan_lazylists():
     assert LazyList(range(10)) < LazyList(range(11))
     assert LazyList([4, 5, 6]) < LazyList([6, 7, 8])
-    
+
+
 def test_greaterthan_lazylists():
     assert LazyList([1, 2, 3]) > LazyList([1, 1])
     assert LazyList(range(11)) > LazyList(range(10))
+
 
 def test_compare_infinite_lists():
     stack = run_vyxal("Þ∞")

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -96,3 +96,20 @@ def test_overdot_X_function_overload():
 def test_beheading_infinite_lists():
     stack = run_vyxal("⁽› 1 Ḟ Ḣ")
     assert stack[-1][0:5] == [2, 3, 4, 5, 6]
+
+def test_equal_lazylists():
+    assert LazyList(range(10)) == LazyList(range(10))
+
+def test_lessthan_lazylists():
+    assert LazyList(range(10)) < LazyList(range(11))
+    assert LazyList([4, 5, 6]) < LazyList([6, 7, 8])
+    
+def test_greaterthan_lazylists():
+    assert LazyList([1, 2, 3]) > LazyList([1, 1])
+    assert LazyList(range(11)) > LazyList(range(10))
+
+def test_compare_infinite_lists():
+    stack = run_vyxal("Þ∞")
+    assert stack[-1] > LazyList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    stack = run_vyxal("Þ∞")
+    assert LazyList([2, 3]) > stack[-1]

--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -67,7 +67,7 @@ class LazyList:
             return self.listify() == other.listify()
         else:
             return False
-    
+
     def __ge__(self, other):
         return self.compare(other) >= 0
 
@@ -156,7 +156,7 @@ class LazyList:
             except StopIteration:
                 break
         return length
-    
+
     def __le__(self, other):
         return self.compare(other) <= 0
 
@@ -190,7 +190,7 @@ class LazyList:
                     return 0
                 else:
                     return -1
-            try: 
+            try:
                 other_item = next(other)
             except StopIteration:
                 return 1

--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -27,6 +27,13 @@ class LazyList:
 
         return gen()
 
+    def __bool__(self):
+        try:
+            next(self)
+            return True
+        except StopIteration:
+            return False
+
     def __call__(self, *args, **kwargs):
         return self
 
@@ -60,13 +67,9 @@ class LazyList:
             return self.listify() == other.listify()
         else:
             return False
-
-    def __bool__(self):
-        try:
-            next(self)
-            return True
-        except StopIteration:
-            return False
+    
+    def __ge__(self, other):
+        return self.compare(other) >= 0
 
     def __getitem__(self, position):
         if isinstance(position, slice):
@@ -124,6 +127,9 @@ class LazyList:
                 else:
                     return 0
 
+    def __gt__(self, other):
+        return self.compare(other) > 0
+
     def __init__(self, source, isinf=False):
         self.raw_object = source
         if isinstance(self.raw_object, types.FunctionType):
@@ -150,6 +156,12 @@ class LazyList:
             except StopIteration:
                 break
         return length
+    
+    def __le__(self, other):
+        return self.compare(other) <= 0
+
+    def __lt__(self, other):
+        return self.compare(other) == -1
 
     def __next__(self):
         from vyxal.helpers import vyxalify
@@ -162,6 +174,30 @@ class LazyList:
         if position >= len(self.generated):
             self.__getitem__(position)
         self.generated[position] = value
+
+    def compare(self, other):
+        # Returns -1 / 0 / 1 depending on whether this is smaller / equal /
+        # greater than `other`
+
+        # Should work for infinite lists
+        item = next(self)
+        other_item = next(other)
+        while item == other_item:
+            try:
+                item = next(self)
+            except StopIteration:
+                if self == other:
+                    return 0
+                else:
+                    return -1
+            try: 
+                other_item = next(other)
+            except StopIteration:
+                return 1
+        if item > other_item:
+            return 1
+        else:
+            return -1
 
     def count(self, other):
         """Number of occurrences of `other` in this `LazyList`"""


### PR DESCRIPTION
Add comparison functions (`__lt__`, `__gt__` etc) for lazylists to allow sorting by lazylists and comparing them in other contexts without errors.