### PR TITLE
Don't use len in all-equal

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -130,3 +130,8 @@ def test_cartesian_product_infinite_lists():
         [3, 1],
         [1, 4],
     ]
+
+
+def test_all_equal_infinite_lists():
+    stack = run_vyxal("Þ∞ ≈")
+    assert stack[-1] == 0

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -136,13 +136,16 @@ def test_cartesian_product_infinite_lists():
         [1, 4],
     ]
 
+
 def test_all_equal_infinite_lists():
     stack = run_vyxal("Þ∞ ≈")
     assert stack[-1] == 0
 
+
 def test_slice_to_end_infinite_lists():
     stack = run_vyxal("⁽›1Ḟ 20 ȯ")
     assert stack[-1][:5] == [21, 22, 23, 24, 25]
+
 
 def test_interleave():
     stack = run_vyxal("⁽›1Ḟ ⁽⇧1Ḟ Y")

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -147,14 +147,13 @@ def all_equal(lhs, ctx):
     (any) -> are all items in a the same?
     """
     lhs = iterable(lhs, ctx=ctx)
-    if len(lhs) == 0:
-        return 1
-    else:
-        first = lhs[0]
-        for item in lhs[1:]:
-            if not non_vectorising_equals(item, first, ctx):
-                return 0
-        return 1
+    first = None
+    for item in lhs:
+        if first is None:
+            first = item
+        elif not non_vectorising_equals(item, first, ctx):
+            return 0
+    return 1
 
 
 def all_less_than_increasing(lhs, rhs, ctx):


### PR DESCRIPTION
Lets `≈` work for infinite lists that are not all equal (doesn't work for infinite lists that are all equal, of course).