### PR TITLE
Add test for slicing to end of infinite lists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -130,3 +130,8 @@ def test_cartesian_product_infinite_lists():
         [3, 1],
         [1, 4],
     ]
+
+
+def test_slice_to_end_infinite_lists():
+    stack = run_vyxal("⁽›1Ḟ 20 ȯ")
+    assert stack[-1][:5] == [21, 22, 23, 24, 25]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -137,12 +137,11 @@ def test_cartesian_product_infinite_lists():
     ]
 
 
-
 def test_slice_to_end_infinite_lists():
     stack = run_vyxal("⁽›1Ḟ 20 ȯ")
     assert stack[-1][:5] == [21, 22, 23, 24, 25]
 
+
 def test_interleave():
     stack = run_vyxal("⁽›1Ḟ ⁽⇧1Ḟ Y")
     assert stack[-1][:6] == [1, 1, 2, 3, 3, 5]
-


### PR DESCRIPTION
`ȯ` was already fixed for infinite lists, this just adds a test for it