### PR TITLE
Make interleave (Y) work on infinite lists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -130,3 +130,8 @@ def test_cartesian_product_infinite_lists():
         [3, 1],
         [1, 4],
     ]
+
+
+def test_interleave():
+    stack = run_vyxal("⁽›1Ḟ ⁽⇧1Ḟ Y")
+    assert stack[-1][:6] == [1, 1, 2, 3, 3, 5]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -1744,17 +1744,25 @@ def interleave(lhs, rhs, ctx):
     rhs = iterable(rhs, ctx=ctx)
 
     @lazylist
-    def f():
-        for i in range(max(len(lhs), len(rhs))):
-            if i < len(lhs):
-                yield lhs[i]
-            if i < len(rhs):
-                yield rhs[i]
+    def gen():
+        lhs_iter = iter(lhs)
+        rhs_iter = iter(rhs)
+        while True:
+            try:
+                yield next(lhs_iter)
+            except StopIteration:
+                yield from rhs_iter
+                break
+            try:
+                yield next(rhs_iter)
+            except StopIteration:
+                yield from lhs_iter
+                break
 
     if type(lhs) is type(rhs) is str:
-        return "".join(f())
+        return "".join(gen())
     else:
-        return f()
+        return gen()
 
 
 def into_two(lhs, ctx):
@@ -4637,7 +4645,7 @@ elements: dict[str, tuple[str, int]] = {
     "ḣ": (
         "top = iterable(pop(stack, 1, ctx), ctx=ctx);"
         " stack.append(head(top, ctx));"
-        " stack.append(index(top, [1, None], ctx))",
+        " stack.append(top[1:])",
         1,
     ),
     "ḭ": process_element(integer_divide, 2),


### PR DESCRIPTION
Uses `iter()`, lemme know if there's a nicer way.

todo Once this is merged, the corresponding task in the [big builtins checklist](https://github.com/Vyxal/Vyxal/issues/586) should be ticked off.