### PR TITLE
Make `ẇ` work with infinite lists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -197,3 +197,8 @@ def test_compressed_strings():
 def test_to_base_digits():
     stack = to_base_digits(64, 2)
     assert stack == [1, 0, 0, 0, 0, 0, 0]
+
+
+def test_wrap_inf():
+    stack = run_vyxal("⁽› 1 Ḟ 3 ẇ")
+    assert stack[-1][:3] == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -219,7 +219,7 @@ def test_apply_to_every_other_inf_list():
     stack = run_vyxal("⁽› 1 Ḟ ⁽› ẇ")
     assert stack[-1][:4] == [1, 3, 3, 5]
 
-    
+
 def test_max_by_function():
     stack = run_vyxal("`word wordier wordiest` ⌈⁽LÞ↑")
     assert stack[-1] == "wordiest"

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -202,3 +202,8 @@ def test_to_base_digits():
 def test_wrap_inf():
     stack = run_vyxal("⁽› 1 Ḟ 3 ẇ")
     assert stack[-1][:3] == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+
+def test_apply_to_every_other_inf_list():
+    stack = run_vyxal("⁽› 1 Ḟ ⁽› ẇ")
+    assert stack[-1][:4] == [1, 3, 3, 5]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -4396,10 +4396,18 @@ def wrap(lhs, rhs, ctx):
         function, vector = (
             (lhs, rhs) if ts[0] is types.FunctionType else (rhs, lhs)
         )
-        return LazyList(
-            safe_apply(function, vector[i], ctx=ctx) if i % 2 else vector[i]
-            for i in range(len(vector))
-        )
+
+        @lazylist
+        def gen():
+            switch = False
+            for item in vector:
+                if switch:
+                    yield safe_apply(function, item, ctx=ctx)
+                else:
+                    yield item
+                switch = not switch
+
+        return gen()
 
     else:
         if ts == (str, str):
@@ -4426,23 +4434,25 @@ def wrap(lhs, rhs, ctx):
 
                 return gen()
 
-            ret, temp = [], []
+            @lazylist
+            def gen():
+                temp = []
+                for item in vector:
+                    temp.append(item)
+                    if len(temp) == chunk_size:
+                        if all(type(x) is str for x in temp):
+                            yield "".join(temp)
+                        else:
+                            yield temp[::]
+                        temp = []
 
-            for item in vector:
-                temp.append(item)
-                if len(temp) == chunk_size:
+                if len(temp) < chunk_size and temp:
                     if all(type(x) is str for x in temp):
-                        ret.append("".join(temp))
+                        yield "".join(temp)
                     else:
-                        ret.append(temp[::])
-                    temp = []
+                        yield temp[::]
 
-            if len(temp) < chunk_size and temp:
-                if all(type(x) is str for x in temp):
-                    ret.append("".join(temp))
-                else:
-                    ret.append(temp[::])
-            return ret
+            return gen()
 
 
 def zero_matrix(lhs, ctx):


### PR DESCRIPTION
Both the list-int and list-fun overloads