### PR TITLE
replace jQuery ready method with regular event listener

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -182,7 +182,7 @@ function copyToClipboard(arg) {
     document.execCommand("copy")
 }
 
-$(document).ready(e => {
+window.addEventListener("DOMContentLoaded", e => {
     const run = document.getElementById("run_button")
     const session = $("session-code")[0].innerHTML
 


### PR DESCRIPTION
fixes #367. i think.

i'm not the best person to ask considering i usually avoid jQuery like the plague, but the `$(document).ready()` method seems finicky here for whatever reason? i loaded the permalink to [Lyxal's most recent CGCC answer in Vyxal](https://codegolf.stackexchange.com/questions/63442/fibonacci-fizz-buzz-fibo-nacci/241719#241719) 25 times before and after the change; the code failed to autorun 13 out of 25 times using jQuery's method, and succeeded 25 times in a row using a plain old event listener.\
extra review from others to corroborate these findings would be appreciated; there is virtually no change to behavior as far as i can tell.