### PR TITLE
wrap online res.stdout setter in try/catch block

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -210,7 +210,11 @@ window.addEventListener("DOMContentLoaded", e => {
                     alert('Please read and ensure you 100% trust the JavaScript code which is about to be evaluated. The code is (see next alert):')
                     alert(res.stdout)
                     if (confirm('Do you want to execute it? If you are remotely unsure, click Cancel!')) {
-                        res.stdout = new Function(res.stdout)()
+                        try {
+                            res.stdout = new Function(res.stdout)()
+                        } catch (e) {
+                            res.stdout = e
+                        }
                     }
                 }
                 output.value = res.stdout


### PR DESCRIPTION
fixes #449.

line 213 is moved into a `try`/`catch` block, and `res.stdout` gets set to the result of the `catch` if necessary.