### PR TITLE
Make some joining flags kinda work with infinite LazyLists

### DIFF
--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -223,29 +223,36 @@ class LazyList:
                 break
         return temp
 
-    def output(self, end="\n", ctx=None):
+    def output(self, open=None, sep=None, close=None, end="\n", ctx=None):
         from vyxal.elements import vy_print, vy_repr
 
         ctx.stacks.append(self.generated)
-        vy_print("⟨ " if ctx.vyxal_lists else "[", "", ctx=ctx)
+        if open is None:
+            open = "⟨ " if ctx.vyxal_lists else "["
+        if sep is None:
+            sep = " | " if ctx.vyxal_lists else ", "
+        if close is None:
+            close = " ⟩" if ctx.vyxal_lists else "]"
+
+        vy_print(open, "", ctx=ctx)
         for lhs in self.generated[:-1]:
-            vy_print(lhs, " | " if ctx.vyxal_lists else ", ", ctx=ctx)
+            vy_print(lhs, sep, ctx=ctx)
         if self.generated:
             vy_print(self.generated[-1], "", ctx=ctx)
 
         try:
             lhs = next(self)
             if len(self.generated) > 1:
-                vy_print(" | " if ctx.vyxal_lists else ", ", "", ctx=ctx)
+                vy_print(sep, "", ctx=ctx)
             while True:
                 if isinstance(lhs, (types.FunctionType, LazyList)):
                     vy_print(lhs, "", ctx=ctx)
                 else:
                     vy_print(vy_repr(lhs, ctx), "", ctx=ctx)
                 lhs = next(self)
-                vy_print(" | " if ctx.vyxal_lists else ", ", "", ctx=ctx)
+                vy_print(sep, "", ctx=ctx)
         except StopIteration:
-            vy_print(" ⟩" if ctx.vyxal_lists else "]", end, ctx=ctx)
+            vy_print(close, end, ctx=ctx)
 
     @lazylist
     def reversed(self):

--- a/vyxal/main.py
+++ b/vyxal/main.py
@@ -190,6 +190,7 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
                             # printed
                             vy_print(acc, end="", ctx=ctx)
                             is_str = True
+                    break
             elif flag == "d":
                 output = vy_sum(deep_flatten(output, ctx), ctx)
             elif flag == "Ṫ":

--- a/vyxal/main.py
+++ b/vyxal/main.py
@@ -158,7 +158,11 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
     output = pop(stack, 1, ctx)
     for flag in flags:
         if flag == "j":
-            output = join(output, "\n", ctx)
+            if isinstance(output, LazyList):
+                output.output(sep="\n", ctx=ctx)
+                break
+            else:
+                output = join(output, "\n", ctx)
         elif flag == "s":
             output = vy_sum(output, ctx)
         elif flag == "d":
@@ -173,7 +177,11 @@ def execute_vyxal(file_name, flags, inputs, output_var=None, online_mode=False):
         elif flag == "L":
             output = vertical_join(output, ctx=ctx)
         elif flag == "S":
-            output = join(output, " ", ctx)
+            if isinstance(output, LazyList):
+                output.output(sep=" ", ctx=ctx)
+                break
+            else:
+                output = join(output, " ", ctx)
         elif flag == "C":
             output = center(output, ctx)
             output = join(output, "\n", ctx)


### PR DESCRIPTION
The good news is that this PR will let `j`, `S`, and `s` work with infinite `LazyList`s. The bad news is that with finite `LazyList`s, it immediately prints them and breaks out of the loop instead of composing other flags on top of those joining flags. I think that's a fine trade-off but obviously y'all should decide whether or not that's okay.

I was an idiot and moved stuff around so the diff is hard to understand, but just look at the if statements for `j`, `S`, and `s` in the flag loop and the `output` method for `LazyList`. Nothing else has really been touched.