### PR TITLE
Make transpose work with infinite lists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -282,3 +282,8 @@ def test_tilde_dyad():
 def test_vectorised_nilad():
     stack = run_vyxal("123 f vkd")
     assert stack[-1][:3] == ["0123456789", "0123456789", "0123456789"]
+
+
+def test_transpose_inf():
+    stack = run_vyxal("Þ∞ ƛÞ∞ +; ∩")
+    assert [row[:3] for row in stack[-1][:3]] == [[2, 3, 4], [3, 4, 5], [4, 5, 6]]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -286,4 +286,8 @@ def test_vectorised_nilad():
 
 def test_transpose_inf():
     stack = run_vyxal("Þ∞ ƛÞ∞ +; ∩")
-    assert [row[:3] for row in stack[-1][:3]] == [[2, 3, 4], [3, 4, 5], [4, 5, 6]]
+    assert [row[:3] for row in stack[-1][:3]] == [
+        [2, 3, 4],
+        [3, 4, 5],
+        [4, 5, 6],
+    ]

--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -169,6 +169,11 @@ class LazyList:
             self.__getitem__(position)
         self.generated[position] = value
 
+    def __delitem__(self, index):
+        if index >= len(self.generated):
+            self.__getitem__(index)
+        del self.generated[index]
+
     def compare(self, other):
         # Returns -1 / 0 / 1 depending on whether this is smaller / equal /
         # greater than `other`

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -4259,7 +4259,7 @@ def vy_int(item: Any, base: int = 10, ctx: Context = DEFAULT_CTX):
         return vy_int(iterable(item, ctx=ctx), base)
 
 
-def vy_map(lhs, rhs, ctx):
+def vy_map_or_pair_each(lhs, rhs, ctx):
     """Element M
     (any, fun) -> apply function b to each element of a
     (any, any) -> a paired with each item of b
@@ -4269,14 +4269,7 @@ def vy_map(lhs, rhs, ctx):
         return LazyList([[lhs, x] for x in iterable(rhs, range, ctx=ctx)])
 
     function, itr = (rhs, lhs) if ts[-1] is types.FunctionType else (lhs, rhs)
-    itr = iterable(itr, range, ctx=ctx)
-
-    @lazylist
-    def gen():
-        for element in itr:
-            yield safe_apply(function, element, ctx=ctx)
-
-    return gen()
+    return vy_map(function, iterable(itr, range, ctx=ctx))
 
 
 def vy_sort(lhs, ctx):
@@ -4685,7 +4678,7 @@ elements: dict[str, tuple[str, int]] = {
     "J": process_element(merge, 2),
     "K": process_element(divisors_or_prefixes, 1),
     "L": process_element(length, 1),
-    "M": process_element(vy_map, 2),
+    "M": process_element(vy_map_or_pair_each, 2),
     "N": process_element(negate, 1),
     "O": process_element(count_item, 2),
     "P": process_element(strip, 2),

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -1044,8 +1044,8 @@ def exponent(lhs, rhs, ctx):
         (str, NUMBER_TYPE): lambda: lhs
         + ((lhs[0] or " ") * (int(rhs) - len(lhs))),
         (str, str): lambda: list(re.search(lhs, rhs).span()),
-        (ts[0], types.FunctionType): lambda: list(vy_map(lhs, rhs, ctx)),
-        (types.FunctionType, ts[1]): lambda: list(vy_map(rhs, lhs, ctx)),
+        (ts[0], types.FunctionType): lambda: list(vy_map(rhs, lhs, ctx)),
+        (types.FunctionType, ts[1]): lambda: list(vy_map(lhs, rhs, ctx)),
     }.get(ts, lambda: vectorise(exponent, lhs, rhs, ctx=ctx))()
 
 
@@ -1591,7 +1591,7 @@ def index_indices_or_cycle(lhs, rhs, ctx):
     else:
         lhs = iterable(lhs)
         rhs = iterable(rhs)
-        return vy_map(rhs, lambda item: lhs[item], ctx=ctx)
+        return vy_map(lambda item: lhs[item], rhs, ctx=ctx)
 
 
 def infinite_cardinals(_, ctx=None):

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -792,7 +792,7 @@ def transpose(
             c += 1
 
     r = 0
-    while r < 10:
+    while True:
         if any(has_ind(row, r) for row in matrix):
             yield gen_row(r)
         else:


### PR DESCRIPTION
Fixes #732. This is probably much more inefficient than before, but it should work for finite lists of finite lists, finite lists of infinite lists, infinite lists of finite lists, and infinite lists of infinite lists.