### PR TITLE
Make `|` parse correctly when its in a structure

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -166,3 +166,28 @@ def test_modifiers_in_char_literals():
     assert str(fully_parse("\\&")) == str(
         [GenericStatement([Token(TokenType.CHARACTER, "&")])]
     )
+
+
+def test_branch_literals_in_structures():
+    assert str(fully_parse("(`|`,")) == str(
+        [
+            ForLoop(
+                [],
+                [
+                    GenericStatement([Token(TokenType.STRING, "|")]),
+                    GenericStatement([Token(TokenType.GENERAL, ",")]),
+                ],
+            )
+        ]
+    )
+
+    assert str(fully_parse("[\\|,")) == str(
+        [
+            IfStatement(
+                [
+                    GenericStatement([Token(TokenType.CHARACTER, "|")]),
+                    GenericStatement([Token(TokenType.GENERAL, ",")]),
+                ],
+            )
+        ]
+    )

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -299,7 +299,7 @@ def _get_branches(tokens: deque[lexer.Token], bracket_stack: list[str]):
             branches[-1].append(token)
             bracket_stack.append(STRUCTURE_INFORMATION[token.value][-1])
 
-        elif token.value == "|":
+        elif token.name == lexer.TokenType.GENERAL and token.value == "|":
             if len(bracket_stack) == 1:
                 # that is, we are in the outer-most structure.
                 branches.append([])


### PR DESCRIPTION
Closes #738