### PR TITLE
Add distance matrix elements

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -3442,7 +3442,7 @@ Distance matrix of undirected graph
 
 ### Overloads
 
-- lst a: `Dstance matrix`
+- lst a: `Distance matrix`
 -------------------------------
 ## `` Þw `` (Distance matrix (Undirected))
 
@@ -3450,7 +3450,7 @@ Distance matrix of undirected graph
 
 ### Overloads
 
-- lst a: `Dstance matrix`
+- lst a: `Distance matrix`
 -------------------------------
 ## `` ¨□ `` (Parse direction arrow to integer)
 

--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -3436,6 +3436,22 @@ A matrix mutliplied by itself n times
 - num a, lst b: `Matrix a mutliplied by itself b times`
 - lst a, num b: `Matrix b mutliplied by itself a times`
 -------------------------------
+## `` Þd `` (Distance matrix (Directed))
+
+Distance matrix of undirected graph
+
+### Overloads
+
+- lst a: `Dstance matrix`
+-------------------------------
+## `` Þw `` (Distance matrix (Undirected))
+
+Distance matrix of undirected graph
+
+### Overloads
+
+- lst a: `Dstance matrix`
+-------------------------------
 ## `` ¨□ `` (Parse direction arrow to integer)
 
 Map characters in `>^<v` to integers (0, 1, 2, 3 respectively)

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -2952,6 +2952,18 @@ k• (Qwerty Keyboard)
     num a, lst b: Matrix a mutliplied by itself b times
     lst a, num b: Matrix b mutliplied by itself a times
 -------------------------------
+Þd (Distance matrix (Directed))
+
+- Distance matrix of undirected graph
+
+    lst a: Dstance matrix
+-------------------------------
+Þw (Distance matrix (Undirected))
+
+- Distance matrix of undirected graph
+
+    lst a: Dstance matrix
+-------------------------------
 ¨□ (Parse direction arrow to integer)
 
 - Map characters in `>^<v` to integers (0, 1, 2, 3 respectively)

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -2956,13 +2956,13 @@ k• (Qwerty Keyboard)
 
 - Distance matrix of undirected graph
 
-    lst a: Dstance matrix
+    lst a: Distance matrix
 -------------------------------
 Þw (Distance matrix (Undirected))
 
 - Distance matrix of undirected graph
 
-    lst a: Dstance matrix
+    lst a: Distance matrix
 -------------------------------
 ¨□ (Parse direction arrow to integer)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4862,6 +4862,26 @@
     - "[[[1, 0, 0], [0, 1, 0], [0, 0, 1]], 3] : [[1, 0, 0], [0, 1, 0], [0, 0, 1]]"
     - "[[1, 2, 3, 4, 5], 4] : [1, 32, 243, 1024, 3125]"
 
+- element: "Þd"
+  name: Distance matrix (Directed)
+  description: Distance matrix of undirected graph
+  arity: 1
+  overloads:
+    lst: Dstance matrix
+  vectorise: false
+  tests:
+    - "[[[1,2],[2,3],[3,4],[4,1],[1,4],[3,6],[5,6]]] : [[0,1,2,1,float('inf'),3],[3,0,1,2,float('inf'),2],[2,3,0,1,float('inf'),1],[1,2,3,0,float('inf'),4],[float('inf'),float('inf'),float('inf'),float('inf'),0,1],[float('inf'),float('inf'),float('inf'),float('inf'),float('inf'),0]]"
+
+- element: "Þw"
+  name: Distance matrix (Undirected)
+  description: Distance matrix of undirected graph
+  arity: 1
+  overloads:
+    lst: Dstance matrix
+  vectorise: false
+  tests:
+    - "[[[1,3],[2,4],[3,4]]] : [[0,3,1,2],[3,0,2,1],[1,2,0,1],[2,1,1,0]]"
+
 - element: "¨□"
   name: Parse direction arrow to integer
   description: Map characters in `>^<v` to integers (0, 1, 2, 3 respectively)

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4867,7 +4867,7 @@
   description: Distance matrix of undirected graph
   arity: 1
   overloads:
-    lst: Dstance matrix
+    lst: Distance matrix
   vectorise: false
   tests:
     - "[[[1,2],[2,3],[3,4],[4,1],[1,4],[3,6],[5,6]]] : [[0,1,2,1,float('inf'),3],[3,0,1,2,float('inf'),2],[2,3,0,1,float('inf'),1],[1,2,3,0,float('inf'),4],[float('inf'),float('inf'),float('inf'),float('inf'),0,1],[float('inf'),float('inf'),float('inf'),float('inf'),float('inf'),0]]"
@@ -4877,7 +4877,7 @@
   description: Distance matrix of undirected graph
   arity: 1
   overloads:
-    lst: Dstance matrix
+    lst: Distance matrix
   vectorise: false
   tests:
     - "[[[1,3],[2,4],[3,4]]] : [[0,3,1,2],[3,0,2,1],[1,2,0,1],[2,1,1,0]]"

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2377,6 +2377,16 @@ A matrix mutliplied by itself n times
 num a, lst b -> Matrix a mutliplied by itself b times
 lst a, num b -> Matrix b mutliplied by itself a times
 `
+codepage_descriptions[100] += `
+Þd (Distance matrix (Directed))
+Distance matrix of undirected graph
+lst a -> Dstance matrix
+`
+codepage_descriptions[119] += `
+Þw (Distance matrix (Undirected))
+Distance matrix of undirected graph
+lst a -> Dstance matrix
+`
 codepage_descriptions[216] += `
 ¨□ (Parse direction arrow to integer)
 Map characters in \`>^<v\` to integers (0, 1, 2, 3 respectively)

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2380,12 +2380,12 @@ lst a, num b -> Matrix b mutliplied by itself a times
 codepage_descriptions[100] += `
 Þd (Distance matrix (Directed))
 Distance matrix of undirected graph
-lst a -> Dstance matrix
+lst a -> Distance matrix
 `
 codepage_descriptions[119] += `
 Þw (Distance matrix (Undirected))
 Distance matrix of undirected graph
-lst a -> Dstance matrix
+lst a -> Distance matrix
 `
 codepage_descriptions[216] += `
 ¨□ (Parse direction arrow to integer)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -21381,6 +21381,52 @@ def test_MatrixExponentiation():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+def test_DistancematrixDirected():
+
+    stack = [vyxalify(item) for item in [[[1,2],[2,3],[3,4],[4,1],[1,4],[3,6],[5,6]]]]
+    expected = vyxalify([[0,1,2,1,float('inf'),3],[3,0,1,2,float('inf'),2],[2,3,0,1,float('inf'),1],[1,2,3,0,float('inf'),4],[float('inf'),float('inf'),float('inf'),float('inf'),0,1],[float('inf'),float('inf'),float('inf'),float('inf'),float('inf'),0]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þd')
+    # print('Þd', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+def test_DistancematrixUndirected():
+
+    stack = [vyxalify(item) for item in [[[1,3],[2,4],[3,4]]]]
+    expected = vyxalify([[0,3,1,2],[3,0,2,1],[1,2,0,1],[2,1,1,0]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þw')
+    # print('Þw', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_Parsedirectionarrowtointeger():
 
     stack = [vyxalify(item) for item in ["v"]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -931,6 +931,28 @@ def diagonal(lhs, ctx):
     return [lhs[i][i] for i in range(len(lhs))]
 
 
+def dist_matrix_dir(lhs, ctx):
+    """Element Þd
+    (lst) -> distance matrix of directed graph"""
+    graph = edges_to_dir_graph(lhs, ctx=ctx)
+    vertices = vy_sort(graph.keys(), ctx=ctx)
+    return [
+        [graph_distance(graph, elem1, elem2) for elem2 in vertices]
+        for elem1 in vertices
+    ]
+
+
+def dist_matrix_undir(lhs, ctx):
+    """Element Þw
+    (lst) -> distance matrix of undirected graph"""
+    graph = edges_to_undir_graph(lhs, ctx=ctx)
+    vertices = vy_sort(graph.keys(), ctx=ctx)
+    return [
+        [graph_distance(graph, elem1, elem2) for elem2 in vertices]
+        for elem1 in vertices
+    ]
+
+
 def divide(lhs, rhs, ctx):
     """Element /
     (num, num) -> a / b
@@ -5458,6 +5480,8 @@ elements: dict[str, tuple[str, int]] = {
     "ÞN": process_element(alternating_negations, 1),
     "Þ□": process_element(identity_matrix, 1),
     "Þe": process_element(matrix_exponentiation, 2),
+    "Þd": process_element(dist_matrix_dir, 1),
+    "Þw": process_element(dist_matrix_undir, 1),
     "¨□": process_element(parse_direction_arrow_to_integer, 1),
     "¨^": process_element(parse_direction_arrow_to_vector, 1),
     "¨,": ("top = pop(stack, 1, ctx); vy_print(top, end=' ', ctx=ctx)", 1),

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -328,6 +328,33 @@ def edges_to_undir_graph(edges: list, ctx: Context) -> dict:
     return graph
 
 
+def graph_distance(
+    graph: dict, vert1, vert2, prev: list = []
+) -> list[list[int]]:
+    """Find the distance from vert1 to vert2 in a directed graph
+
+    Parameters:
+    graph: `dict[Vertex, list[Vertex]]`\\
+    A dictionary where keys are vertices and values are lists of
+    neighboring vertices
+    prev: `list[Vertex]`\\
+    A list of previously visited vertices, to avoid going in cycles"""
+    if vert1 == vert2:
+        return 0
+    # I know this is the American spelling, but it's shorter than neighbour
+    neighbors = [neighbor for neighbor in graph[vert1] if neighbor not in prev]
+    if not neighbors:
+        return float("inf")
+    elif vert2 in neighbors:
+        return 1
+    else:
+        new_prev = prev + [vert1]
+        return 1 + min(
+            graph_distance(graph, neighbor, vert2, new_prev)
+            for neighbor in neighbors
+        )
+
+
 def has_ind(lst: VyList, ind: int) -> bool:
     """Whether or not the list is long enough for that index"""
     if isinstance(lst, LazyList):


### PR DESCRIPTION
Implements the last part of #807. `Þd` for distance of directed matrices and `Þw` for distance of undirected matrices. We need a better symbol for the second one, though.