### PR TITLE
Make it so that `x` or `X` after a modifier functions correctly.

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+from ast import Break
 import os
 import sys
 
@@ -189,6 +190,52 @@ def test_branch_literals_in_structures():
                 [
                     GenericStatement([Token(TokenType.CHARACTER, "|")]),
                     GenericStatement([Token(TokenType.GENERAL, ",")]),
+                ],
+            )
+        ]
+    )
+
+
+def test_break_works_good_with_modifiers():
+    assert str(fully_parse("vX")) == str(
+        [MonadicModifier("v", BreakStatement(None))]
+    )
+
+    assert str(fully_parse("₌XX")) == str(
+        [DyadicModifier("₌", BreakStatement(None), BreakStatement(None))]
+    )
+
+    assert str(fully_parse("≬3dX")) == str(
+        [
+            Lambda(
+                "default",
+                [
+                    GenericStatement([Token(TokenType.NUMBER, "3")]),
+                    GenericStatement([Token(TokenType.GENERAL, "d")]),
+                    BreakStatement(None),
+                ],
+            )
+        ]
+    )
+
+
+def test_break_works_good_with_modifiers():
+    assert str(fully_parse("vx")) == str(
+        [MonadicModifier("v", RecurseStatement(None))]
+    )
+
+    assert str(fully_parse("₌xx")) == str(
+        [DyadicModifier("₌", RecurseStatement(None), RecurseStatement(None))]
+    )
+
+    assert str(fully_parse("≬3dx")) == str(
+        [
+            Lambda(
+                "default",
+                [
+                    GenericStatement([Token(TokenType.NUMBER, "3")]),
+                    GenericStatement([Token(TokenType.GENERAL, "d")]),
+                    RecurseStatement(None),
                 ],
             )
         ]

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -221,7 +221,15 @@ def parse(
             # modifier.
             if not tokens:
                 break
-            remaining = parse(tokens, structure.MonadicModifier)
+            remaining = parse(tokens)
+            relevant = remaining[0]
+
+            if isinstance(
+                remaining[0],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[0].parent_structure = parent
+
             if head.value == "⁽":
                 # 1-element lambda
                 structures.append(
@@ -237,6 +245,19 @@ def parse(
             if not tokens:
                 break
             remaining = parse(tokens, structure.DyadicModifier)
+
+            if isinstance(
+                remaining[0],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[0].parent_structure = parent
+
+            if isinstance(
+                remaining[1],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[1].parent_structure = parent
+
             if head.value == "‡":
                 # 2-element lambda
                 structures.append(
@@ -255,6 +276,23 @@ def parse(
         elif head.value in TRIADIC_MODIFIERS:
             if not tokens:
                 break
+            if isinstance(
+                remaining[0],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[0].parent_structure = parent
+
+            if isinstance(
+                remaining[1],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[1].parent_structure = parent
+
+            if isinstance(
+                remaining[2],
+                (structure.RecurseStatement, structure.BreakStatement),
+            ):
+                remaining[2].parent_structure = parent
             remaining = parse(tokens, structure.TriadicModifier)
             if head.value == "≬":
                 # 3-element lambda

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -244,7 +244,7 @@ def parse(
         elif head.value in DYADIC_MODIFIERS:
             if not tokens:
                 break
-            remaining = parse(tokens, structure.DyadicModifier)
+            remaining = parse(tokens)
 
             if isinstance(
                 remaining[0],
@@ -276,6 +276,7 @@ def parse(
         elif head.value in TRIADIC_MODIFIERS:
             if not tokens:
                 break
+            remaining = parse(tokens)
             if isinstance(
                 remaining[0],
                 (structure.RecurseStatement, structure.BreakStatement),
@@ -293,7 +294,6 @@ def parse(
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
                 remaining[2].parent_structure = parent
-            remaining = parse(tokens, structure.TriadicModifier)
             if head.value == "≬":
                 # 3-element lambda
                 structures.append(


### PR DESCRIPTION
Fixes #846 