### PR TITLE
Document `∆I` and `¨ẇ`

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -2649,6 +2649,14 @@ Get the nth digit of pi
 - num a: `nth_digit_of_pi(a)`
 - str a: `antiderivative of a`
 -------------------------------
+## `` ∆I `` (First N Digits of Pi)
+
+Generate the first n digits of pi
+
+### Overloads
+
+- num a: `the first (a + 1)th digits of pi`
+-------------------------------
 ## `` ∆Ė `` (N Digits of Euler's Number (e) / Sympy Evaluate)
 
 Get the first n digits of Euler's number (e) / evaluate an expression as sympy
@@ -3559,4 +3567,12 @@ Usage:
 ¨£<element>
 ```
 
+-------------------------------
+## `` ¨ẇ `` (Wrap Last n Items)
+
+Wrap the last n items on the stack into a list
+
+### Overloads
+
+- num a: `last a items in a list`
 -------------------------------

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -2324,6 +2324,12 @@ k• (Qwerty Keyboard)
     str a: antiderivative of a
     otherwise: vectorise
 -------------------------------
+∆I (First N Digits of Pi)
+
+- Generate the first n digits of pi
+
+    num a: the first (a + 1)th digits of pi
+-------------------------------
 ∆Ė (N Digits of Euler's Number (e) / Sympy Evaluate)
 
 - Get the first n digits of Euler's number (e) / evaluate an expression as sympy
@@ -3048,4 +3054,10 @@ k• (Qwerty Keyboard)
 
     ¨£<element>
 
+-------------------------------
+¨ẇ (Wrap Last n Items)
+
+- Wrap the last n items on the stack into a list
+
+    num a: last a items in a list
 -------------------------------

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -3746,6 +3746,20 @@
       - "[8] : 5"
       - "[9] : 3"
 
+- element: "∆I"
+  name: First N Digits of Pi
+  description: Generate the first n digits of pi
+  arity: 1
+  overloads:
+      num: the first (a + 1)th digits of pi
+  vectorise: false
+  tests:
+      - "[1] : [3, 1]"
+      - "[2] : [3, 1, 4]"
+      - "[3] : [3, 1, 4, 1]"
+      - "[4] : [3, 1, 4, 1, 5]"
+      - "[5] : [3, 1, 4, 1, 5, 9]"
+
 - element: "∆Ė"
   name: N Digits of Euler's Number (e) / Sympy Evaluate
   arity: 1
@@ -4288,9 +4302,9 @@
       - "[[1, 2, 3, 4, 1, 2, 3, 4], 3, 6, 1] : [1, 2, 6, 4, 1, 2, 3, 4]"
       - "[[1, 1, 1, 1], 1, 4, 3] : [1, 1, 4, 1]"
       - '["aaaa", "G", "w", 1] : "aaaa"'
-      - '[[1, 2, 3, 4], 5, 6, 2] : [1, 2, 3, 4]'
+      - "[[1, 2, 3, 4], 5, 6, 2] : [1, 2, 3, 4]"
       - '["abcaabc", "a", "d", -2] : "abcdabc"'
-      - '[[1, 2, 2, 3, 4, 2, 5, 3], 2, 8, -1] : [1, 2, 2, 3, 4, 8, 5, 3]'
+      - "[[1, 2, 2, 3, 4, 2, 5, 3], 2, 8, -1] : [1, 2, 2, 3, 4, 8, 5, 3]"
 
 - element: "Þ*"
   name: Cartesian product over list
@@ -4896,20 +4910,20 @@
   description: Distance matrix of undirected graph
   arity: 1
   overloads:
-    lst: Distance matrix
+      lst: Distance matrix
   vectorise: false
   tests:
-    - "[[[1,2],[2,3],[3,4],[4,1],[1,4],[3,6],[5,6]]] : [[0,1,2,1,float('inf'),3],[3,0,1,2,float('inf'),2],[2,3,0,1,float('inf'),1],[1,2,3,0,float('inf'),4],[float('inf'),float('inf'),float('inf'),float('inf'),0,1],[float('inf'),float('inf'),float('inf'),float('inf'),float('inf'),0]]"
+      - "[[[1,2],[2,3],[3,4],[4,1],[1,4],[3,6],[5,6]]] : [[0,1,2,1,float('inf'),3],[3,0,1,2,float('inf'),2],[2,3,0,1,float('inf'),1],[1,2,3,0,float('inf'),4],[float('inf'),float('inf'),float('inf'),float('inf'),0,1],[float('inf'),float('inf'),float('inf'),float('inf'),float('inf'),0]]"
 
 - element: "Þw"
   name: Distance matrix (Undirected)
   description: Distance matrix of undirected graph
   arity: 1
   overloads:
-    lst: Distance matrix
+      lst: Distance matrix
   vectorise: false
   tests:
-    - "[[[1,3],[2,4],[3,4]]] : [[0,3,1,2],[3,0,2,1],[1,2,0,1],[2,1,1,0]]"
+      - "[[[1,3],[2,4],[3,4]]] : [[0,3,1,2],[3,0,2,1],[1,2,0,1],[2,1,1,0]]"
 
 - element: "¨□"
   name: Parse direction arrow to integer
@@ -5011,3 +5025,15 @@
   name: Star Map
   description: Reduce each pair of two lists zipped together by a function. Equivalent to Zvƒ
   usage: "¨£<element>"
+
+- element: "¨ẇ"
+  name: Wrap Last n Items
+  description: Wrap the last n items on the stack into a list
+  arity: 1
+  overloads:
+      num: last a items in a list
+  vectorise: false
+  tests:
+      - "[1, 2, 3, 4, 4] : [1, 2, 3, 4]"
+      - "[3, 3, 3, 3, 3, 3, 3, 3, 3, 3] : [3, 3, 3]"
+      - "[[1, 2, 3, 4], 1] : [[1, 2, 3, 4]]"

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -1871,6 +1871,11 @@ Get the nth digit of pi
 num a -> nth_digit_of_pi(a)
 str a -> antiderivative of a
 `
+codepage_descriptions[73] += `
+∆I (First N Digits of Pi)
+Generate the first n digits of pi
+num a -> the first (a + 1)th digits of pi
+`
 codepage_descriptions[187] += `
 ∆Ė (N Digits of Euler's Number (e) / Sympy Evaluate)
 Get the first n digits of Euler's number (e) / evaluate an expression as sympy
@@ -2452,3 +2457,8 @@ codepage_descriptions.push(`Star Map
 Reduce each pair of two lists zipped together by a function. Equivalent to Zvƒ
 `)
 
+codepage_descriptions[157] += `
+¨ẇ (Wrap Last n Items)
+Wrap the last n items on the stack into a list
+num a -> last a items in a list
+`

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -16061,6 +16061,113 @@ def test_nthDigitofPiIntegrate():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+def test_FirstNDigitsofPi():
+
+    stack = [vyxalify(item) for item in [1]]
+    expected = vyxalify([3, 1])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('∆I')
+    # print('∆I', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [2]]
+    expected = vyxalify([3, 1, 4])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('∆I')
+    # print('∆I', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [3]]
+    expected = vyxalify([3, 1, 4, 1])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('∆I')
+    # print('∆I', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [4]]
+    expected = vyxalify([3, 1, 4, 1, 5])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('∆I')
+    # print('∆I', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [5]]
+    expected = vyxalify([3, 1, 4, 1, 5, 9])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('∆I')
+    # print('∆I', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_NDigitsofEulersNumbereSympyEvaluate():
 
     stack = [vyxalify(item) for item in [[0, 1, 2, '5 ** 2']]]
@@ -21909,6 +22016,71 @@ def test_StrictLessThan():
 
     code = transpile('¨<')
     # print('¨<', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+def test_WrapLastnItems():
+
+    stack = [vyxalify(item) for item in [1, 2, 3, 4, 4]]
+    expected = vyxalify([1, 2, 3, 4])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('¨ẇ')
+    # print('¨ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [3, 3, 3, 3, 3, 3, 3, 3, 3, 3]]
+    expected = vyxalify([3, 3, 3])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('¨ẇ')
+    # print('¨ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [[1, 2, 3, 4], 1]]
+    expected = vyxalify([[1, 2, 3, 4]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('¨ẇ')
+    # print('¨ẇ', code)
     exec(code)
 
     ctx.stacks.pop()


### PR DESCRIPTION
Closes #859

- `øF` isn't documented because it was more of a joke and should probably be removed.