### PR TITLE
Make ṡ return a Lazylist object instead of a range

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3810,9 +3810,9 @@ def sort_by(lhs, rhs, ctx):
         )
     else:
         return {
-            (NUMBER_TYPE, NUMBER_TYPE): lambda: range(lhs, rhs + 1)
+            (NUMBER_TYPE, NUMBER_TYPE): lambda: LazyList(range(lhs, rhs + 1))
             if lhs <= rhs
-            else range(lhs, rhs - 1, -1),
+            else LazyList(range(lhs, rhs - 1, -1)),
             (str, str): lambda: re.split(rhs, lhs),
         }.get(ts, lambda: vectorise(sort_by, lhs, rhs, ctx=ctx))()
 


### PR DESCRIPTION
Closes #910

I honestly don't know how this happened.