### PR TITLE
Make callers of foldl work with empty lists

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -2348,7 +2348,7 @@ def left_bit_shift(lhs, rhs, ctx):
     """
     ts = vy_type(lhs, rhs)
     return {
-        (NUMBER_TYPE, NUMBER_TYPE): lambda: lhs << rhs,
+        (NUMBER_TYPE, NUMBER_TYPE): lambda: int(lhs) << int(rhs),
         (NUMBER_TYPE, str): lambda: rhs.ljust(lhs),
         (str, NUMBER_TYPE): lambda: lhs.ljust(rhs),
         (str, str): lambda: lhs.ljust(len(rhs)),
@@ -5197,7 +5197,10 @@ def vy_sum(lhs, ctx=None):
     """Element ∑
     (any) -> reduce a by addition
     """
-    return foldl(add, iterable(lhs, ctx=ctx), ctx=ctx)
+    lhs = iterable(lhs, ctx=ctx)
+    if not lhs:
+        return 0
+    return foldl(add, lhs, ctx=ctx)
 
 
 def vy_print(lhs, end="\n", ctx=None):

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -523,6 +523,9 @@ def max_by(vec: VyList, key=lambda x: x, cmp=None, ctx=DEFAULT_CTX):
         def cmp(a, b, ctx=None):
             return a > b
 
+    if not vec:
+        return 0
+
     return foldl(
         lambda a, b, ctx=ctx: a
         if safe_apply(
@@ -556,6 +559,9 @@ def min_by(vec: VyList, key=None, cmp=None, ctx=DEFAULT_CTX):
 
         def cmp(a, b, ctx=None):
             return a < b
+
+    if not vec:
+        return 0
 
     return foldl(
         lambda a, b, ctx=ctx: a


### PR DESCRIPTION
This is not good practice at all, but this PR also makes `<<` turn its arguments into `int`s before doing the bit shifting.

For `min_by` and `max_by`, if the list is empty, it returns 0.