### PR TITLE
Implement all indices

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -3221,6 +3221,15 @@ Index a list of coordinates into a value.
 
 - lst a, lst b: `a[b[0]][b[1]][b[2]]... Reduce by indexing with a as initial value`
 -------------------------------
+## `` ÞI `` (All Indices)
+
+All indices of element in list (multidimensional)
+
+### Overloads
+
+- lst a, any b: `All indices of b in a`
+- str a, str b: `All occurrences of substring b in a`
+-------------------------------
 ## `` Þḟ `` (Multidimensional Search)
 
 Find the first multidimensional index of a value in another

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -2791,6 +2791,13 @@ k• (Qwerty Keyboard)
 
     lst a, lst b: a[b[0]][b[1]][b[2]]... Reduce by indexing with a as initial value
 -------------------------------
+ÞI (All Indices)
+
+- All indices of element in list (multidimensional)
+
+    lst a, any b: All indices of b in a
+    str a, str b: All occurrences of substring b in a
+-------------------------------
 Þḟ (Multidimensional Search)
 
 - Find the first multidimensional index of a value in another

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4162,7 +4162,7 @@
       - '["withree"] : "`wi∧ḭ`"'
       - '["hello"] : "`ƈṙ`"'
       - '["Vyxal"] : "`₴ŀ`"'
-      - '["abcdef`gh"] : "`ėġḣ²\`gh`"'
+      - '["abcdef`gh"] : "`ėġḣ²\\`gh`"'
 
 - element: "øW"
   name: Group on words
@@ -4609,15 +4609,16 @@
       - '[["xyzabc"], [0,4]] : "b"'
 
 - element: "ÞI"
-  name: All Indices
-  description: All indices of element in list (multidimensional)
+  name: All Indices (Multidimensional)
+  description: All multidimensional indices of element in list
   arity: 2
   overloads:
       lst-any: All indices of b in a
-      str-str: All occurrences of substring b in a
+      any-lst: All indices of a in b
+      any-any: All indices of b in a
   vectorise: false
   tests:
-      - "['barbaz','ba'] : [0, 3]"
+      - "[[[[3], [3,4], [[3]]], [3]], [3]] : [[0,0], [0,2,0], [1]]"
 
 - element: "Þḟ"
   name: Multidimensional Search

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -4608,6 +4608,17 @@
       - "[[1,[2,3]],[1,0]] : 2"
       - '[["xyzabc"], [0,4]] : "b"'
 
+- element: "ÞI"
+  name: All Indices
+  description: All indices of element in list (multidimensional)
+  arity: 2
+  overloads:
+      lst-any: All indices of b in a
+      str-str: All occurrences of substring b in a
+  vectorise: false
+  tests:
+      - "['barbaz','ba'] : [0, 3]"
+
 - element: "Þḟ"
   name: Multidimensional Search
   description: Find the first multidimensional index of a value in another

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2237,6 +2237,12 @@ codepage_descriptions[105] += `
 Index a list of coordinates into a value.
 lst a, lst b -> a[b[0]][b[1]][b[2]]... Reduce by indexing with a as initial value
 `
+codepage_descriptions[73] += `
+ÞI (All Indices)
+All indices of element in list (multidimensional)
+lst a, any b -> All indices of b in a
+str a, str b -> All occurrences of substring b in a
+`
 codepage_descriptions[145] += `
 Þḟ (Multidimensional Search)
 Find the first multidimensional index of a value in another

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -20877,6 +20877,29 @@ def test_MultidimensionalIndexing():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+def test_AllIndices():
+
+    stack = [vyxalify(item) for item in ['barbaz','ba']]
+    expected = vyxalify([0, 3])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ÞI')
+    # print('ÞI', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_MultidimensionalSearch():
 
     stack = [vyxalify(item) for item in [[[1,2,3],[4,5,6]], 5]]

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -18004,7 +18004,7 @@ def test_DictionaryCompression():
 
 
     stack = [vyxalify(item) for item in ["abcdef`gh"]]
-    expected = vyxalify("`ėġḣ²\`gh`")
+    expected = vyxalify("`ėġḣ²\\`gh`")
     ctx = Context()
 
     ctx.stacks.append(stack)
@@ -20877,10 +20877,10 @@ def test_MultidimensionalIndexing():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-def test_AllIndices():
+def test_AllIndicesMultidimensional():
 
-    stack = [vyxalify(item) for item in ['barbaz','ba']]
-    expected = vyxalify([0, 3])
+    stack = [vyxalify(item) for item in [[[[3], [3,4], [[3]]], [3]], [3]]]
+    expected = vyxalify([[0,0], [0,2,0], [1]])
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -204,7 +204,6 @@ def all_indices(lhs, rhs, ctx):
     lst, elem = (lhs, rhs) if ts[0] == list else (rhs, lhs)
 
 
-
 def all_less_than_increasing(lhs, rhs, ctx):
     """Element Þ<
     (any, num): All values of a up to (not including) the first greater

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -2783,12 +2783,9 @@ def multi_dimensional_search(lhs, rhs, ctx):
                   multidimensional index
     """
     lhs = iterable(lhs, ctx=ctx)
-    indexes = enumerate_md(lhs)
 
-    for ind in indexes:
-        if non_vectorising_equals(
-            multi_dimensional_index(lhs, ind, ctx), rhs, ctx
-        ):
+    for ind, item in enumerate_md(lhs):
+        if non_vectorising_equals(item, rhs, ctx):
             return ind
 
     return []

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -190,6 +190,21 @@ def all_equal(lhs, ctx):
     return 1
 
 
+def all_indices(lhs, rhs, ctx):
+    """Element ÞI
+    (lst, any) -> All indices of rhs in lhs (multidimensional)
+    (num|str, lst) -> All indices of lhs in rhs (multidimensional)
+    (str, str) -> All indices of substring rhs in lhs (multidimensional)
+    """
+    ts = vy_type(lhs, rhs)
+
+    if ts == (str, str):
+        return [i for i in range(len(lhs)) if lhs.startswith(rhs, i)]
+
+    lst, elem = (lhs, rhs) if ts[0] == list else (rhs, lhs)
+
+
+
 def all_less_than_increasing(lhs, rhs, ctx):
     """Element Þ<
     (any, num): All values of a up to (not including) the first greater
@@ -5918,6 +5933,7 @@ elements: dict[str, tuple[str, int]] = {
     ),
     "Þǔ": process_element(untruth, 1),
     "Þi": process_element(multi_dimensional_index, 2),
+    "ÞI": process_element(all_indices, 2),
     "Þḟ": process_element(multi_dimensional_search, 2),
     "Þm": process_element(zero_matrix, 1),
     "Þ…": process_element(evenly_distribute, 2),

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -120,15 +120,24 @@ def digits(num: NUMBER_TYPE) -> List[int]:
 
 
 @lazylist
-def enumerate_md(haystack: VyList, _index_stack: tuple = ()) -> VyList:
-    """Gets all the multi-dimensional indices of haystack"""
+def enumerate_md(haystack: VyList, _index_stack: tuple = (), include_all = False) -> VyList:
+    """Enumerate multi-dimensional indices and items of a list.
+
+    Parameters:
+    include_str:
+    Whether nested lists should be included as items too
+    """
     for i, item in enumerate(haystack):
         if type(item) in (list, LazyList):
-            yield from enumerate_md(item, _index_stack + (i,))
+            if include_all:
+                yield (list(_index_stack) + [i], item)
+            yield from enumerate_md(item, _index_stack + (i,), include_all)
         elif type(item) is str and len(item) > 1:
-            yield from enumerate_md(list(item), _index_stack + (i,))
+            if include_all:
+                yield (list(_index_stack) + [i], item)
+            yield from enumerate_md(list(item), _index_stack + (i,), include_all)
         else:
-            yield list(_index_stack) + [i]
+            yield (list(_index_stack) + [i], item)
 
 
 def first_where(


### PR DESCRIPTION
Will eventually close #971. Also modifies `enumerate_md` to act more like Python's enumerate (yields tuples `(index, item)` instead of just indices)