### PR TITLE
Make `Ǐ` no longer vectorise by default 

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1926,6 +1926,7 @@ prime factorization / append first element
 
 - num a: `prime_factorization(a)`
 - str a: `a + a[0]`
+- lst a: `a + [a[0]]`
 -------------------------------
 ## `` ǐ `` (Prime factors)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1639,6 +1639,7 @@ z (Zip-self)
 
     num a: prime_factorization(a)
     str a: a + a[0]
+    lst a: a + [a[0]]
 -------------------------------
 ǐ (Prime factors)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1639,7 +1639,6 @@ z (Zip-self)
 
     num a: prime_factorization(a)
     str a: a + a[0]
-    otherwise: vectorise
 -------------------------------
 ǐ (Prime factors)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -2590,10 +2590,12 @@
   overloads:
       num: prime_factorization(a)
       str: a + a[0]
-  vectorise: true
+  vectorise: false
   tests:
       - "[45] : [3,5]"
       - '["abc"] : "abca"'
+      - "[[1, 2, 3]] : [1, 2, 3, 1]"
+      - "[[]] : []"
 
 - element: "ǐ"
   name: Prime factors

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -2590,6 +2590,7 @@
   overloads:
       num: prime_factorization(a)
       str: a + a[0]
+      lst: a + [a[0]]
   vectorise: false
   tests:
       - "[45] : [3,5]"

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -1334,6 +1334,7 @@ codepage_descriptions.push(`Prime factorization
 prime factorization / append first element
 num a -> prime_factorization(a)
 str a -> a + a[0]
+lst a -> a + [a[0]]
 `)
 
 codepage_descriptions.push(`Prime factors

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -11399,6 +11399,48 @@ def test_Primefactorization():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+    stack = [vyxalify(item) for item in [[1, 2, 3]]]
+    expected = vyxalify([1, 2, 3, 1])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ǐ')
+    # print('Ǐ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [[]]]
+    expected = vyxalify([])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ǐ')
+    # print('Ǐ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_Primefactors():
 
     stack = [vyxalify(item) for item in [45]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3355,7 +3355,8 @@ def prime_factorisation(lhs, ctx):
     ts = vy_type(lhs)
     return {
         NUMBER_TYPE: lambda: sympy.ntheory.primefactors(int(lhs)),
-    }.get(ts, lambda: lhs + lhs[0])()
+        str: lambda: lhs + lhs[0],
+    }.get(ts, lambda: lhs + [lhs[0]] if lhs else lhs)()
 
 
 def prepend(lhs, rhs, ctx):

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3355,8 +3355,7 @@ def prime_factorisation(lhs, ctx):
     ts = vy_type(lhs)
     return {
         NUMBER_TYPE: lambda: sympy.ntheory.primefactors(int(lhs)),
-        str: lambda: lhs + lhs[0],
-    }.get(ts, lambda: vectorise(prime_factorisation, lhs, ctx=ctx))()
+    }.get(ts, lambda: lhs + lhs[0])()
 
 
 def prepend(lhs, rhs, ctx):


### PR DESCRIPTION
Closes #961 