### PR TITLE
Make vectorised recursion (`vx`) work again

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -769,3 +769,8 @@ def test_infinite_all_integers():
 def test_dyadic_modifier_monadically():
     stack = run_vyxal("3 ₍d")
     assert stack[-1] == [6, 3]
+
+
+def test_vectorized_recursion():
+    stack = run_vyxal("λ⅛-[vx];†¾", inputs=[[[1,2],3,[2,3]]])
+    assert stack[-1] == [[[1, 2], 3, [2, 3]], [1, 2], 1, 2, 3, [2, 3], 2, 3]

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -772,5 +772,5 @@ def test_dyadic_modifier_monadically():
 
 
 def test_vectorized_recursion():
-    stack = run_vyxal("λ⅛-[vx];†¾", inputs=[[[1,2],3,[2,3]]])
+    stack = run_vyxal("λ⅛-[vx];†¾", inputs=[[[1, 2], 3, [2, 3]]])
     assert stack[-1] == [[[1, 2], 3, [2, 3]], [1, 2], 1, 2, 3, [2, 3], 2, 3]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -6825,9 +6825,9 @@ modifiers: dict[str, str] = {
     ),
     "v": (
         "arguments = wrapify(stack, function_A.arity if function_A.arity != 0 else 1, ctx=ctx)\n"
-        "stack.append"
-        "(vectorise(function_A, *(arguments[::-1]), explicit=True, ctx=ctx))"
-        "\n"
+        "res = vectorise(function_A, *(arguments[::-1]), explicit=True, ctx=ctx)\n"
+        "if eager: res = list(res)\n"
+        "stack.append(res)"
     ),
     "¨v": (
         "arguments = wrapify(stack, function_A.arity if function_A.arity != 0 else 1, ctx=ctx)\n"

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -256,7 +256,7 @@ def parse(
                 remaining[0],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[0].parent_structure = parent
+                remaining[0].parent_structure = structure.MonadicModifier
 
             if head.value == "⁽":
                 # 1-element lambda
@@ -285,13 +285,13 @@ def parse(
                 remaining[0],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[0].parent_structure = parent
+                remaining[0].parent_structure = structure.DyadicModifier
 
             if isinstance(
                 remaining[1],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[1].parent_structure = parent
+                remaining[1].parent_structure = structure.DyadicModifier
 
             if head.value == "‡":
                 # 2-element lambda
@@ -316,19 +316,19 @@ def parse(
                 remaining[0],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[0].parent_structure = parent
+                remaining[0].parent_structure = structure.TriadicModifier
 
             if isinstance(
                 remaining[1],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[1].parent_structure = parent
+                remaining[1].parent_structure = structure.TriadicModifier
 
             if isinstance(
                 remaining[2],
                 (structure.RecurseStatement, structure.BreakStatement),
             ):
-                remaining[2].parent_structure = parent
+                remaining[2].parent_structure = structure.TriadicModifier
             if head.value == "≬":
                 # 3-element lambda
                 structures.append(

--- a/vyxal/transpile.py
+++ b/vyxal/transpile.py
@@ -361,9 +361,15 @@ def transpile_structure(
             indent,
             options=options,
         )
+
+        eager = isinstance(
+            struct.function_A,
+            (vyxal.structure.RecurseStatement, vyxal.structure.BreakStatement),
+        )
         return (
             element_A
             + "\n"
+            + indent_str("eager = " + str(eager), indent)
             + indent_str("function_A = pop(stack, 1, ctx)", indent)
             + indent_str(modifiers.get(struct.modifier, "pass"), indent)
         )


### PR DESCRIPTION
makes the transpiler use the function_stack instead of this

#857 broke this, btw.