### PR TITLE
Finally fix ẇ

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1255,6 +1255,9 @@ Wrap a list in chunks of a certain length / apply a function to every second ite
 ### Overloads
 
 - any a, num b: `a wrapped in chunks of length b`
+- num a, any b: `b wrapped in chunks of length a`
+- any a, lst b: `Wrap a into chunks with lengths given in b, repeating if necessary`
+- lst a, str b: `Wrap b into chunks with lengths given in a, repeating if necessary`
 - any a, fun b: `Apply b to every second item of a`
 - fun a, any b: `Apply a to every second item of b`
 - str a, str b: `split a on first occurance of b`

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1074,6 +1074,9 @@ z (Zip-self)
 - Wrap a list in chunks of a certain length / apply a function to every second item of a list
 
     any a, num b: a wrapped in chunks of length b
+    num a, any b: b wrapped in chunks of length a
+    any a, lst b: Wrap a into chunks with lengths given in b, repeating if necessary
+    lst a, str b: Wrap b into chunks with lengths given in a, repeating if necessary
     any a, fun b: Apply b to every second item of a
     fun a, any b: Apply a to every second item of b
     str a, str b: split a on first occurance of b

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1691,6 +1691,9 @@
   arity: 2
   overloads:
       any-num: a wrapped in chunks of length b
+      num-any: b wrapped in chunks of length a
+      any-lst: Wrap a into chunks with lengths given in b, repeating if necessary
+      lst-str: Wrap b into chunks with lengths given in a, repeating if necessary
       any-fun: Apply b to every second item of a
       fun-any: Apply a to every second item of b
       str-str: split a on first occurance of b
@@ -1700,6 +1703,14 @@
       - "[[1,2,3,4,5,6],3] : [[1,2,3],[4,5,6]]"
       - '["abcdefghi",[2,3,4]] : ["ab","cde","fghi"]'
       - "[[1,2,3,4,5], [2,3] ] : [[1,2],[3,4,5]]"
+      - "[[1,2,3,4,5], [2,3,4] ] : [[1,2],[3,4,5]]"
+      - "[[1,2,3,4,5, 6, 7, 8, 9, 10], [2,3] ] : [[1,2],[3,4,5],[6,7],[8,9,10]]"
+      - '[["abc","def","ghi", "jkl"], 2] : [["abc","def"],["ghi","jkl"]]'
+      - '[["abc","def","ghi", "jkl"], [2,3]] : [["abc","def"],["ghi","jkl"]]'
+      - '["abcdefg",2] : ["ab","cd","ef","g"]'
+      - '["abca", "a"] : ["","bca"]'
+      - '["defg", "g"] : ["def",""]'
+      - '["defg", "x"] : ["defg"]'
 
 - element: "ẋ"
   name: Repeat

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -879,6 +879,9 @@ any a -> a[:-1],a[-1]
 codepage_descriptions.push(`Chunk Wrap
 Wrap a list in chunks of a certain length / apply a function to every second item of a list
 any a, num b -> a wrapped in chunks of length b
+num a, any b -> b wrapped in chunks of length a
+any a, lst b -> Wrap a into chunks with lengths given in b, repeating if necessary
+lst a, str b -> Wrap b into chunks with lengths given in a, repeating if necessary
 any a, fun b -> Apply b to every second item of a
 fun a, any b -> Apply a to every second item of b
 str a, str b -> split a on first occurance of b

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -7634,6 +7634,174 @@ def test_ChunkWrap():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+    stack = [vyxalify(item) for item in [[1,2,3,4,5], [2,3,4] ]]
+    expected = vyxalify([[1,2],[3,4,5]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [[1,2,3,4,5, 6, 7, 8, 9, 10], [2,3] ]]
+    expected = vyxalify([[1,2],[3,4,5],[6,7],[8,9,10]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [["abc","def","ghi", "jkl"], 2]]
+    expected = vyxalify([["abc","def"],["ghi","jkl"]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [["abc","def","ghi", "jkl"], [2,3]]]
+    expected = vyxalify([["abc","def"],["ghi","jkl"]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abcdefg",2]]
+    expected = vyxalify(["ab","cd","ef","g"])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abca", "a"]]
+    expected = vyxalify(["","bca"])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["defg", "g"]]
+    expected = vyxalify(["def",""])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["defg", "x"]]
+    expected = vyxalify(["defg"])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ẇ')
+    # print('ẇ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_Repeat():
 
     stack = [vyxalify(item) for item in [[1,2,3],3]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5478,6 +5478,7 @@ def wrap(lhs, rhs, ctx):
             fun, elem = lhs, rhs
         else:
             fun, elem = rhs, lhs
+
         @lazylist
         def gen():
             apply = False
@@ -5511,6 +5512,7 @@ def wrap(lhs, rhs, ctx):
                     yield "".join(working)
                 else:
                     yield working
+
         return gen()
 
     elif ts == (str, str):
@@ -5526,6 +5528,7 @@ def wrap(lhs, rhs, ctx):
         else:
             elem, wraps = rhs, lhs
         print(elem, wraps, ts)
+
         @lazylist
         def gen():
             working = []
@@ -5535,7 +5538,7 @@ def wrap(lhs, rhs, ctx):
                 if len(working) == lengths[0]:
                     if vy_type(elem) == str:
                         yield "".join(working)
-                    else: 
+                    else:
                         yield working
                     working = []
                     lengths = lengths[1:] + [lengths[0]]
@@ -5546,7 +5549,7 @@ def wrap(lhs, rhs, ctx):
                     yield working
 
         return gen()
-    
+
 
 def zero_length_range(lhs, ctx):
     """Element ẏ


### PR DESCRIPTION
Fix #937 by reimplementing `ẇ` from the ground up.

Now, there's sensible behaviour on all types, where before several overloads were broken or produced cursed results.

In particular, string lists will return (lists of) string lists, ***not*** concatenate them. Also, some overloads will work both ways. Don't worry, it doesn't break anything.