### PR TITLE
Make abs diff vectorise

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1393,14 +1393,16 @@ Transpose (filling with spaces) and then join on newlines
 
 - any a: `Transpose a, join on newlines`
 -------------------------------
-## `` ε `` (Absolute Difference / Padded Vertical Join)
+## `` ε `` (Absolute Difference / Repeat / Regex match)
 
-Returns the aboslute different (|a - b|) or vertically joins using padding
+Returns the aboslute difference / Fills an array of a certain length / Does a regex match
 
 ### Overloads
 
 - num a, num b: `abs(a - b)`
-- any a, str b: `Transpose a (filling with b), join on newlines`
+- num a, str b: `[b] * a`
+- str a, num b: `[a] * b`
+- str a, str b: `Do a regex match of b on a`
 -------------------------------
 ## `` ¡ `` (Factorial)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1195,12 +1195,14 @@ z (Zip-self)
 
     any a: Transpose a, join on newlines
 -------------------------------
-ε (Absolute Difference / Padded Vertical Join)
+ε (Absolute Difference / Repeat / Regex match)
 
-- Returns the aboslute different (|a - b|) or vertically joins using padding
+- Returns the aboslute difference / Fills an array of a certain length / Does a regex match
 
     num a, num b: abs(a - b)
-    any a, str b: Transpose a (filling with b), join on newlines
+    num a, str b: [b] * a
+    str a, num b: [a] * b
+    str a, str b: Do a regex match of b on a
 -------------------------------
 ¡ (Factorial)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1892,19 +1892,27 @@
       - '[[1, 22, 333]] : "  3\n 23\n123"'
 
 - element: "ε"
-  name: Absolute Difference / Padded Vertical Join
+  name: Absolute Difference / Repeat / Regex match
   arity: 2
-  description: Returns the aboslute different (|a - b|) or vertically joins using padding
+  description: Returns the aboslute difference / Fills an array of a certain length / Does a regex match
   overloads:
       num-num: abs(a - b)
-      any-str: Transpose a (filling with b), join on newlines
+      num-str: "[b] * a"
+      str-num: "[a] * b"
+      str-str: Do a regex match of b on a
   vectorise: false
   tests:
       - "[5, 1] : 4"
       - "[1, 5] : 4"
       - "[3, 3] : 0"
-      - '[["***", "****", "*****"], "."] : "..*\n.**\n***\n***\n***"'
-      - '[["abc", "def", "ghi"], "."] : "adg\nbeh\ncfi"'
+      - "[[1, 2, 3], 4] : [3, 2, 1]"
+      - '["hello", 2] : ["hello", "hello"]'
+      - '[3, "goodbye"] : ["goodbye", "goodbye", "goodbye"]'
+      - '[["ab", "cd"], 2] : [["ab", "ab"], ["cd", "cd"]]'
+      - '["abcd", ".*"] : "abcd"'
+      - '["abcd", "a.."] : "abc"'
+      - '["abcd", "efg"] : ""'
+
 
 - element: "¡"
   name: Factorial

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -981,10 +981,12 @@ Transpose (filling with spaces) and then join on newlines
 any a -> Transpose a, join on newlines
 `)
 
-codepage_descriptions.push(`Absolute Difference / Padded Vertical Join
-Returns the aboslute different (|a - b|) or vertically joins using padding
+codepage_descriptions.push(`Absolute Difference / Repeat / Regex match
+Returns the aboslute difference / Fills an array of a certain length / Does a regex match
 num a, num b -> abs(a - b)
-any a, str b -> Transpose a (filling with b), join on newlines
+num a, str b -> [b] * a
+str a, num b -> [a] * b
+str a, str b -> Do a regex match of b on a
 `)
 
 codepage_descriptions.push(`Factorial

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -8527,7 +8527,7 @@ def test_VerticalJoin():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-def test_AbsoluteDifferencePaddedVerticalJoin():
+def test_AbsoluteDifferenceRepeatRegexmatch():
 
     stack = [vyxalify(item) for item in [5, 1]]
     expected = vyxalify(4)
@@ -8592,8 +8592,8 @@ def test_AbsoluteDifferencePaddedVerticalJoin():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [["***", "****", "*****"], "."]]
-    expected = vyxalify("..*\n.**\n***\n***\n***")
+    stack = [vyxalify(item) for item in [[1, 2, 3], 4]]
+    expected = vyxalify([3, 2, 1])
     ctx = Context()
 
     ctx.stacks.append(stack)
@@ -8613,8 +8613,113 @@ def test_AbsoluteDifferencePaddedVerticalJoin():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [["abc", "def", "ghi"], "."]]
-    expected = vyxalify("adg\nbeh\ncfi")
+    stack = [vyxalify(item) for item in ["hello", 2]]
+    expected = vyxalify(["hello", "hello"])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ε')
+    # print('ε', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [3, "goodbye"]]
+    expected = vyxalify(["goodbye", "goodbye", "goodbye"])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ε')
+    # print('ε', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [["ab", "cd"], 2]]
+    expected = vyxalify([["ab", "ab"], ["cd", "cd"]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ε')
+    # print('ε', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abcd", ".*"]]
+    expected = vyxalify("abcd")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ε')
+    # print('ε', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abcd", "a.."]]
+    expected = vyxalify("abc")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('ε')
+    # print('ε', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abcd", "efg"]]
+    expected = vyxalify("")
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -78,7 +78,9 @@ def absolute_difference(lhs, rhs, ctx):
         (NUMBER_TYPE, NUMBER_TYPE): lambda: abs(lhs - rhs),
         (NUMBER_TYPE, str): lambda: [rhs] * lhs,
         (str, NUMBER_TYPE): lambda: [lhs] * rhs,
-        (str, str): lambda: re.match(rhs, lhs) and re.match(rhs, lhs).group() or "",
+        (str, str): lambda: re.match(rhs, lhs)
+        and re.match(rhs, lhs).group()
+        or "",
     }.get(ts, lambda: vectorise(absolute_difference, lhs, rhs, ctx=ctx))()
 
 


### PR DESCRIPTION
And other stuff

Fixes #958 

`ε` now has some flash new overloads as well - str-num creates an array of strings with a certain length, str-str does a single regex match.