### PR TITLE
Made ctrl/cmd + enter work on Mac

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -260,7 +260,7 @@ window.addEventListener("DOMContentLoaded", e => {
 })
 
 document.addEventListener('keydown', (event) => {
-    if (event.ctrlKey && event.key == 'Enter') {
+    if (event.metaKey && event.key == 'Enter') {
         $("#run_button").click()
     }
 })


### PR DESCRIPTION
`event.metaKey` is ctrl on Windows and cmd on Mac.