### PR TITLE
Make the arguments of `ß` go in the right order

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -655,6 +655,20 @@ def test_string_interop():
     assert stack[-1] == "hello 2 world 1"
 
 
+def test_conditional_execute_modifier():
+    stack = run_vyxal("12 19 1 ß%")
+    assert stack[-1] == 12
+
+    stack = run_vyxal("12 19 0 ß%")
+    assert stack[-1] == 19
+
+    stack = run_vyxal("12 19 1 ßd")
+    assert stack[-1] == 38
+
+    stack = run_vyxal("12 19 0 ßd")
+    assert stack[-1] == 19
+
+
 def test_generators():
     stack = run_vyxal('1 1" ⁽+ d Ḟ')
     assert stack[-1][:7] == [1, 1, 2, 3, 5, 8, 13]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -6651,8 +6651,7 @@ modifiers: dict[str, str] = {
     ),
     "ß": (
         "if boolify(pop(stack, 1, ctx), ctx):\n"
-        "    stack.append(function_A)\n"
-        "    function_call(stack, ctx)"
+        "    stack.append(safe_apply(function_A, *stack, ctx=ctx))\n"
     ),
     "¨=": (
         "original = pop(stack, 1, ctx)\n"


### PR DESCRIPTION
No related issue, just something that came up in chat.