### PR TITLE
Fix dyadic modifiers when used monadically

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -748,3 +748,8 @@ def test_infinite_all_integers():
         -9,
         10,
     ]
+
+
+def test_dyadic_modifier_monadically():
+    stack = run_vyxal("3 ₍d")
+    assert stack[-1] == [6, 3]

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -275,7 +275,11 @@ def parse(
             remaining = parse(tokens)
 
             if len(remaining) < 2:
-                remaining.append(structure.GenericStatement([lexer.Token(lexer.TokenType.GENERAL, '\n')]))
+                remaining.append(
+                    structure.GenericStatement(
+                        [lexer.Token(lexer.TokenType.GENERAL, "\n")]
+                    )
+                )
 
             if isinstance(
                 remaining[0],

--- a/vyxal/parse.py
+++ b/vyxal/parse.py
@@ -274,6 +274,9 @@ def parse(
                 break
             remaining = parse(tokens)
 
+            if len(remaining) < 2:
+                remaining.append(structure.GenericStatement([lexer.Token(lexer.TokenType.GENERAL, '\n')]))
+
             if isinstance(
                 remaining[0],
                 (structure.RecurseStatement, structure.BreakStatement),


### PR DESCRIPTION
It simply appends the second element as an identity function.
