### PR TITLE
Fix the mysteriously failing `i`

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -816,6 +816,8 @@ Index into a list
 ### Overloads
 
 - any a, num b: `a[b] (index)`
+- num a, any b: `b[a] (index)`
+- str a, str b: `enclose b in a (b[0:len(b)//2] + a + b[len(b)//2:])`
 - any a, [x] b: `a[:b] (0 to bth item of a)`
 - any a, [x,y] b: `a[x:y] (x to yth item of a)`
 - any a, [x,y,m] b: `a[x:y:m] (x to yth item of a, taking every mth)`

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -711,6 +711,8 @@ i (Index)
 - Index into a list
 
     any a, num b: a[b] (index)
+    num a, any b: b[a] (index)
+    str a, str b: enclose b in a (b[0:len(b)//2] + a + b[len(b)//2:])
     any a, [x] b: a[:b] (0 to bth item of a)
     any a, [x,y] b: a[x:y] (x to yth item of a)
     any a, [x,y,m] b: a[x:y:m] (x to yth item of a, taking every mth)

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1192,6 +1192,7 @@
   vectorise: false
   tests:
       - '["abc",[1,2]] : "b"'
+      - '["joemama","biden''s"] : "joebiden''smama"'
       - "[[1,2,3], 0] : 1"
       - "[[1,2,3], -1] : 3"
       - "[[1,2,3], -0.1] : 1"

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1184,21 +1184,22 @@
   arity: 2
   overloads:
       any-num: a[b] (index)
+      num-any: b[a] (index)
+      str-str: enclose b in a (b[0:len(b)//2] + a + b[len(b)//2:])
       any-[x]: a[:b] (0 to bth item of a)
       any-[x,y]: a[x:y] (x to yth item of a)
       any-[x,y,m]: a[x:y:m] (x to yth item of a, taking every mth)
   vectorise: false
   tests:
-      - '["abc",1] : "b"'
+      - '["abc",[1,2]] : "b"'
       - "[[1,2,3], 0] : 1"
       - "[[1,2,3], -1] : 3"
       - "[[1,2,3], -0.1] : 1"
       - "[[1,2,3], 1.9] : 2"
       - "[[2,3,4,5], [2]] : [2,3]"
       - "[[1,3,5,7],[1,3]] : [3,5]"
-      - "[1357,[1,3]] : 35"
+      - "[4,[1,3,4]] : 3"
       - "[[1,2,3,4,5,6,7,8,9,10],[1,8,2]] : [2,4,6,8]"
-      - "[12345678910,[1,8,2]] : 2468"
 
 - element: "j"
   name: Join

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -583,6 +583,8 @@ any a -> a[0] (first item)
 codepage_descriptions.push(`Index
 Index into a list
 any a, num b -> a[b] (index)
+num a, any b -> b[a] (index)
+str a, str b -> enclose b in a (b[0:len(b)//2] + a + b[len(b)//2:])
 any a, [x] b -> a[:b] (0 to bth item of a)
 any a, [x,y] b -> a[x:y] (x to yth item of a)
 any a, [x,y,m] b -> a[x:y:m] (x to yth item of a, taking every mth)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -6626,7 +6626,7 @@ def test_Head():
 
 def test_Index():
 
-    stack = [vyxalify(item) for item in ["abc",1]]
+    stack = [vyxalify(item) for item in ["abc",[1,2]]]
     expected = vyxalify("b")
     ctx = Context()
 
@@ -6773,8 +6773,8 @@ def test_Index():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [1357,[1,3]]]
-    expected = vyxalify(35)
+    stack = [vyxalify(item) for item in [4,[1,3,4]]]
+    expected = vyxalify(3)
     ctx = Context()
 
     ctx.stacks.append(stack)
@@ -6796,27 +6796,6 @@ def test_Index():
 
     stack = [vyxalify(item) for item in [[1,2,3,4,5,6,7,8,9,10],[1,8,2]]]
     expected = vyxalify([2,4,6,8])
-    ctx = Context()
-
-    ctx.stacks.append(stack)
-
-    code = transpile('i')
-    # print('i', code)
-    exec(code)
-
-    ctx.stacks.pop()
-    actual = vyxalify(stack[-1])
-
-    print(simplify(expected), simplify(actual))
-
-    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
-        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
-    else:
-        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
-
-
-    stack = [vyxalify(item) for item in [12345678910,[1,8,2]]]
-    expected = vyxalify(2468)
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -6647,6 +6647,27 @@ def test_Index():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+    stack = [vyxalify(item) for item in ["joemama","biden's"]]
+    expected = vyxalify("joebiden'smama")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('i')
+    # print('i', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
     stack = [vyxalify(item) for item in [[1,2,3], 0]]
     expected = vyxalify(1)
     ctx = Context()

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -2032,11 +2032,11 @@ def increment_until_false(lhs, rhs, ctx):
 def index(lhs, rhs, ctx):
     """Element i
     (any, num) -> a[b] (Index)
+    (num, any) -> b[a] (Index)
     (str, str) -> enclose b in a # b[0:len(b)//2] + a + b[len(b)//2:]
     (any, [x]) -> a[:b] (0 to bth item of a)
     (any, [x,y]) -> a[x:y] (x to yth item of a)
     (any, [x,y,m]) -> a[x:y:m] (x to yth item of a, taking every mth)
-    (num, any) -> b[a] (Index)
     """
     ts = vy_type(lhs, rhs)
     lhs = deep_copy(lhs)
@@ -2047,29 +2047,24 @@ def index(lhs, rhs, ctx):
     elif ts == (LazyList, NUMBER_TYPE):
         return lhs[int(rhs)]
 
-    elif ts[-1] == NUMBER_TYPE:
-        if len(iterable(lhs)):
-            return iterable(lhs, ctx=ctx)[int(rhs) % len(iterable(lhs, ctx))]
+    elif ts[1] == NUMBER_TYPE:
+        lhs = iterable(lhs, ctx=ctx)
+        if lhs:
+            return lhs[int(rhs) % len(lhs)]
         else:
             return "" if ts[0] is str else 0
 
     elif ts[0] == NUMBER_TYPE:
         return index(rhs, lhs, ctx)
 
-    elif ts[-1] == str:
+    elif ts[1] == str:
         return vectorise(index, lhs, rhs, ctx=ctx)
 
     else:
-        originally_string = False
-        if isinstance(lhs, str):
-            lhs = LazyList(list(lhs))
-            originally_string = True
-        temp = iterable(lhs, ctx=ctx)[
+        assert len(rhs) <= 3
+        return lhs[
             slice(*[None if vy_type(v) != NUMBER_TYPE else int(v) for v in rhs])
         ]
-        if originally_string:
-            return "".join(temp)
-        return temp
 
 
 def index_indices_or_cycle(lhs, rhs, ctx):


### PR DESCRIPTION
#1119 marked `i`'s behavior when given `1357, [1, 3]` as a bug, but it's a feature (for real this time). There's a `num-any` overload that does `b[a]`. It and the `str-str` overload are now documented and each have a test.