### PR TITLE
Fix behavior of `/` and `Þ÷` when splitting strings/lists

### DIFF
--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -5229,6 +5229,7 @@
       num-any: divide b into a parts, possibly with an extra part
   vectorise: false
   tests:
+      - "[[1,2,3,4,5,6,7,8], 3] : [[1,2],[3,4],[5,6],[7,8]]"
       - "[[1,2,3,4,5,6,7,8,9], 3] : [[1,2,3],[4,5,6],[7,8,9]]"
 
 - element: "ÞZ"

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -28796,6 +28796,27 @@ def test_ZeroMatrix():
 
 def test_Dividelistintonparts():
 
+    stack = [vyxalify(item) for item in [[1,2,3,4,5,6,7,8], 3]]
+    expected = vyxalify([[1,2],[3,4],[5,6],[7,8]])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þ÷')
+    # print('Þ÷', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
     stack = [vyxalify(item) for item in [[1,2,3,4,5,6,7,8,9], 3]]
     expected = vyxalify([[1,2,3],[4,5,6],[7,8,9]])
     ctx = Context()

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -1241,8 +1241,8 @@ def divide(lhs, rhs, ctx):
         (NUMBER_TYPE, NUMBER_TYPE): lambda: 0
         if rhs == 0
         else vyxalify(sympy.nsimplify(lhs / rhs)),
-        (NUMBER_TYPE, str): lambda: wrap(rhs, len(rhs) // lhs, ctx),
-        (str, NUMBER_TYPE): lambda: wrap(lhs, len(lhs) // rhs, ctx),
+        (NUMBER_TYPE, str): lambda: chop(rhs, lhs),
+        (str, NUMBER_TYPE): lambda: chop(lhs, rhs),
         (str, str): lambda: lhs.split(rhs),
     }.get(ts, lambda: vectorise(divide, lhs, rhs, ctx=ctx))()
 
@@ -1255,7 +1255,7 @@ def divide_lists(lhs, rhs, ctx):
     ts = vy_type(lhs, rhs, simple=True)
     if ts[1] == list:
         return divide_lists(rhs, lhs, ctx)
-    return wrap(lhs, len(lhs) // rhs, ctx)
+    return chop(lhs, rhs)
 
 
 def divisors_or_prefixes(lhs, ctx):

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -29,6 +29,7 @@ from vyxal.LazyList import *
 NUMBER_TYPE = "number"
 SCALAR_TYPE = "scalar"
 VyList = Union[list, LazyList]
+VyIterable = Union[str, VyList]
 
 
 def case_of(value: str) -> int:
@@ -39,6 +40,17 @@ def case_of(value: str) -> int:
     elif all(map(lambda x: x.islower(), value)):
         return 0
     return -1
+
+
+@lazylist
+def chop(it: VyIterable, n: int) -> LazyList:
+    """Chop `it` into `n` equal chunks, plus an optional extra piece for leftovers."""
+    chunk_len = len(it) // n
+
+    for i in range(n):
+        yield it[i * chunk_len : (i + 1) * chunk_len]
+    if n * chunk_len < len(it):
+        yield it[n * chunk_len :]
 
 
 @lazylist
@@ -189,7 +201,7 @@ def foldl(
     return working if working is not None else 0
 
 
-def format_string(pattern: str, data: Union[str, VyList]) -> str:
+def format_string(pattern: str, data: VyIterable) -> str:
     """Returns the pattern formatted with the given data. If the data is
     a string, then the string is reused if there is more than one % to
     be formatted. Otherwise (the data is a list), % are cyclically
@@ -510,9 +522,7 @@ def local_maxima(lhs: str) -> List[Union[int, float]]:
     return LazyList(z for z in zeros if second_dx.subs(x, z) < 0)
 
 
-def longest_suffix(
-    a: Union[str, VyList], b: Union[str, VyList]
-) -> Union[str, VyList]:
+def longest_suffix(a: VyIterable, b: VyIterable) -> VyIterable:
     """Find the longest suffix of a pair of strings or lists.
     If bothare strings, the result is a string."""
     i = 1
@@ -905,7 +915,7 @@ def stationary_points(lhs: str) -> List[Union[int, float]]:
     return LazyList(zeros)
 
 
-def suffixes(lhs: Union[str, VyList], ctx: Context) -> VyList:
+def suffixes(lhs: VyIterable, ctx: Context) -> VyList:
     """Returns a list of suffixes, including the original list"""
     if isinstance(lhs, str):
         return [lhs[-i:] for i in range(len(lhs), 0, -1)]


### PR DESCRIPTION
I couldn't see how to get `wrap` to do exactly what we want, so I made a helper for it. Hope that's okay. Goes towards closing #1119