### PR TITLE
Fix tests for `Ẋ` and `ÞẊ`

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1616,7 +1616,8 @@ Split a value and keep the delimiter
 -------------------------------
 ## `` Ẋ `` (Cartesian Product / Fixpoint)
 
-Take the Cartesian Product of two values, or apply a function until there is no change.
+Take the Cartesian Product of two values, or apply a function until there is no change. If arguments are numbers, turns them into ranges.
+
 
 ### Overloads
 
@@ -3325,7 +3326,8 @@ Depth of ragged list
 -------------------------------
 ## `` ÞẊ `` (Cartesian Power)
 
-Cartesian power, cartesian product with self n times
+Cartesian power, cartesian product with self n times. If both arguments are numbers, turns the left into a range.
+
 
 ### Overloads
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1379,7 +1379,8 @@ z (Zip-self)
 -------------------------------
 Ẋ (Cartesian Product / Fixpoint)
 
-- Take the Cartesian Product of two values, or apply a function until there is no change.
+- Take the Cartesian Product of two values, or apply a function until there is no change. If arguments are numbers, turns them into ranges.
+
 
     any a, any b: cartesian-product(a,b)
     fun a, any b: apply a on b until b does not change
@@ -2886,7 +2887,8 @@ k• (Qwerty Keyboard)
 -------------------------------
 ÞẊ (Cartesian Power)
 
-- Cartesian power, cartesian product with self n times
+- Cartesian power, cartesian product with self n times. If both arguments are numbers, turns the left into a range.
+
 
     any a, num b: cartesian_power(a, b)
     num a, any b: cartesian_power(b, a)

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -2449,7 +2449,9 @@
 
 - element: "Ẋ"
   name: Cartesian Product / Fixpoint
-  description: Take the Cartesian Product of two values, or apply a function until there is no change.
+  description: >
+      Take the Cartesian Product of two values, or apply a function until there is no change.
+      If arguments are numbers, turns them into ranges.
   arity: 2
   overloads:
       any-any: cartesian-product(a,b)
@@ -2459,7 +2461,7 @@
       - '["ab","cd"] : ["ac","ad","bc","bd"]'
       - '["ab",["c","d"]] : [["a","c"],["a","d"],["b","c"],["b","d"]]'
       - "[[1,2],[3,4]] : [[1,3],[1,4],[2,3],[2,4]]"
-      - "[12,34] : [13,14,23,24]"
+      - "[2,3] : [[1,1],[1,2],[2,1],[1,3],[2,2],[2,3]]"
 
 - element: "Ẏ"
   name: Slice Until
@@ -5075,7 +5077,9 @@
 
 - element: "ÞẊ"
   name: Cartesian Power
-  description: Cartesian power, cartesian product with self n times
+  description: >
+    Cartesian power, cartesian product with self n times.
+    If both arguments are numbers, turns the left into a range.
   arity: 2
   overloads:
       any-num: cartesian_power(a, b)
@@ -5088,7 +5092,7 @@
       - '["ab",0] : []'
       - '["ab",1] : ["a","b"]'
       - "[[], 2] : []"
-      - "[12,2] : [11,12,21,22]"
+      - "[2,2] : [[1,1],[2,1],[1,2],[2,2]]"
 
 - element: "Þf"
   name: Flatten By depth

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -1137,7 +1137,8 @@ fun a, any b -> apply a to every second item of b starting on the first item
 `)
 
 codepage_descriptions.push(`Cartesian Product / Fixpoint
-Take the Cartesian Product of two values, or apply a function until there is no change.
+Take the Cartesian Product of two values, or apply a function until there is no change. If arguments are numbers, turns them into ranges.
+
 any a, any b -> cartesian-product(a,b)
 fun a, any b -> apply a on b until b does not change
 `)
@@ -2314,7 +2315,8 @@ lst a -> Depth
 `
 codepage_descriptions[201] += `
 ÞẊ (Cartesian Power)
-Cartesian power, cartesian product with self n times
+Cartesian power, cartesian product with self n times. If both arguments are numbers, turns the left into a range.
+
 any a, num b -> cartesian_power(a, b)
 num a, any b -> cartesian_power(b, a)
 `

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -15043,8 +15043,8 @@ def test_CartesianProductFixpoint():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [12,34]]
-    expected = vyxalify([13,14,23,24])
+    stack = [vyxalify(item) for item in [2,3]]
+    expected = vyxalify([[1,1],[1,2],[2,1],[1,3],[2,2],[2,3]])
     ctx = Context()
 
     ctx.stacks.append(stack)
@@ -28228,8 +28228,8 @@ def test_CartesianPower():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [12,2]]
-    expected = vyxalify([11,12,21,22])
+    stack = [vyxalify(item) for item in [2,2]]
+    expected = vyxalify([[1,1],[2,1],[1,2],[2,2]])
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/vyxal/context.py
+++ b/vyxal/context.py
@@ -47,11 +47,15 @@ class Context:
 
         ctx.context_values = self.context_values
         ctx.inputs = self.inputs
-        ctx.number_as_range = self.number_as_range if number_as_range is None else number_as_range
+        ctx.number_as_range = (
+            self.number_as_range if number_as_range is None else number_as_range
+        )
         ctx.online = self.online
         ctx.online_output = self.online_output
         ctx.printed = self.printed
-        ctx.range_start = self.range_start if range_start is None else range_start
+        ctx.range_start = (
+            self.range_start if range_start is None else range_start
+        )
         ctx.range_end = self.range_end
         ctx.repl_mode = self.repl_mode
         ctx.retain_popped = self.retain_popped

--- a/vyxal/context.py
+++ b/vyxal/context.py
@@ -41,17 +41,17 @@ class Context:
         self.global_array = []
         self.canvas = Canvas()
 
-    def copy(self):
+    def copy(self, number_as_range=None, range_start=None):
         """Copy itself so a modified version can be passed elsewhere."""
         ctx = Context()
 
         ctx.context_values = self.context_values
         ctx.inputs = self.inputs
-        ctx.number_as_range = self.number_as_range
+        ctx.number_as_range = self.number_as_range if number_as_range is None else number_as_range
         ctx.online = self.online
         ctx.online_output = self.online_output
         ctx.printed = self.printed
-        ctx.range_start = self.range_start
+        ctx.range_start = self.range_start if range_start is None else range_start
         ctx.range_end = self.range_end
         ctx.repl_mode = self.repl_mode
         ctx.retain_popped = self.retain_popped

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -768,9 +768,13 @@ def cartesian_power(lhs, rhs, ctx):
     if NUMBER_TYPE not in ts:
         return rhs
 
-    vector, n = (lhs, rhs) if ts[-1] == NUMBER_TYPE else (rhs, lhs)
-    vector = iterable(vector, ctx=ctx)
+    if ts[0] == NUMBER_TYPE and ts[1] != NUMBER_TYPE:
+        vector, n = rhs, lhs
+    else:
+        vector, n = lhs, rhs
+    vector = list(vector) if isinstance(vector, str) else iterable(vector, ctx=ctx.copy(number_as_range=True))
     n = int(n)
+    print(f"vec={vector}, n={n}")
     if n < 1 or not vector:
         return []
     elif n == 1:
@@ -850,8 +854,8 @@ def cartesian_product(lhs, rhs, ctx):
     elif ts == (str, str):
         return [left + right for left in lhs for right in rhs]
     else:
-        lhs = iterable(lhs, range, ctx=ctx)
-        rhs = iterable(rhs, range, ctx=ctx)
+        lhs = iterable(lhs, ctx=ctx.copy(number_as_range=True))
+        rhs = iterable(rhs, ctx=ctx.copy(number_as_range=True))
 
         @lazylist
         def gen():

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -772,7 +772,11 @@ def cartesian_power(lhs, rhs, ctx):
         vector, n = rhs, lhs
     else:
         vector, n = lhs, rhs
-    vector = list(vector) if isinstance(vector, str) else iterable(vector, ctx=ctx.copy(number_as_range=True))
+    vector = (
+        list(vector)
+        if isinstance(vector, str)
+        else iterable(vector, ctx=ctx.copy(number_as_range=True))
+    )
     n = int(n)
     print(f"vec={vector}, n={n}")
     if n < 1 or not vector:


### PR DESCRIPTION
`ÞẊ` now turns string arguments into lists of characters and turns numbers into ranges. The docs and tests for both now reflect this.