### PR TITLE
Make `gen_from_fn` (`Ḟ`) work with LazyLists

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -707,7 +707,7 @@ def test_generators():
     stack = run_vyxal('1 1" ⁽+ Ḟ')
     assert stack[-1][:7] == [1, 1, 2, 4, 8, 16, 32]
 
-    stack = run_vyxal('1 1" ⁽d Ḟ')
+    stack = run_vyxal('⁽d Ḟ', inputs=[LazyList([1, 1])])
     assert stack[-1][:7] == [1, 1, 2, 4, 8, 16, 32]
 
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -707,7 +707,7 @@ def test_generators():
     stack = run_vyxal('1 1" ⁽+ Ḟ')
     assert stack[-1][:7] == [1, 1, 2, 4, 8, 16, 32]
 
-    stack = run_vyxal('⁽d Ḟ', inputs=[LazyList([1, 1])])
+    stack = run_vyxal("⁽d Ḟ", inputs=[LazyList([1, 1])])
     assert stack[-1][:7] == [1, 1, 2, 4, 8, 16, 32]
 
 

--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -274,6 +274,12 @@ class LazyList:
             vy_print(close, end, ctx=ctx)
 
     @lazylist
+    def appended(self, value):
+        yield from self
+        yield value
+
+
+    @lazylist
     def reversed(self):
         self.generated += list(itertools.tee(self.raw_object)[-1])
         for item in self.generated[::-1]:

--- a/vyxal/LazyList.py
+++ b/vyxal/LazyList.py
@@ -278,7 +278,6 @@ class LazyList:
         yield from self
         yield value
 
-
     @lazylist
     def reversed(self):
         self.generated += list(itertools.tee(self.raw_object)[-1])

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -1793,14 +1793,20 @@ def gen_from_fn(lhs, rhs, ctx):
     def gen():
         yield from lhs
 
-        made = lhs[:]
+        if isinstance(lhs, LazyList):
+            made = lhs
+        else:
+            made = lhs[:]
 
         func_arity = (
             rhs.stored_arity if "stored_arity" in dir(rhs) else rhs.arity
         )
         while True:
             ret = safe_apply(rhs, *made[-func_arity:], ctx=ctx)
-            made.append(ret)
+            if isinstance(made, LazyList):
+                made = made.appended(ret)
+            else:
+                made.append(ret)
             yield ret
 
     return LazyList(gen(), isinf=True)


### PR DESCRIPTION
It was trying to call the `append` method, which only works for lists.