### PR TITLE
Make `Þİ`  work with swapped args

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -3807,6 +3807,7 @@ Push the first n items of a, then the rest of a
 ### Overloads
 
 - lst a, int b: `a[:b], a[b:]`
+- int a, lst b: `b[:a], b[a:]`
 -------------------------------
 ## `` ÞN `` (Alternating Negation)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -3259,6 +3259,7 @@ k• (Qwerty Keyboard)
 - Push the first n items of a, then the rest of a
 
     lst a, int b: a[:b], a[b:]
+    int a, lst b: b[:a], b[a:]
 -------------------------------
 ÞN (Alternating Negation)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -5857,10 +5857,12 @@
   arity: 2
   overloads:
       lst-int: a[:b], a[b:]
+      int-lst: b[:a], b[a:]
   vectorise: false
   tests:
       - "[[1, 2, 3, 4, 5, 6, 7, 8, 9], 4] : [5, 6, 7, 8, 9]"
       - "['abcde', 2] : 'cde'"
+      - "[1, 'xyz'] : 'yz'"
 
 - element: "ÞN"
   name: Alternating Negation

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2623,6 +2623,7 @@ codepage_descriptions[191] += `
 Þİ (First n Items and Rest)
 Push the first n items of a, then the rest of a
 lst a, int b -> a[:b], a[b:]
+int a, lst b -> b[:a], b[a:]
 `
 codepage_descriptions[78] += `
 ÞN (Alternating Negation)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -33431,6 +33431,27 @@ def test_FirstnItemsandRest():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+    stack = [vyxalify(item) for item in [1, 'xyz']]
+    expected = vyxalify('yz')
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Þİ')
+    # print('Þİ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_IdentityMatrixofSizen():
 
     stack = [vyxalify(item) for item in [3]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -6639,6 +6639,8 @@ elements: dict[str, tuple[str, int]] = {
     "ÞT": process_element(multidimensional_truthy_indices, 1),
     "Þİ": (
         "rhs, lhs = pop(stack, 2, ctx)\n"
+        "if vy_type(rhs) != NUMBER_TYPE:\n"
+        "    lhs, rhs = rhs, lhs\n"
         "stack.append(index(lhs, [0, rhs], ctx))\n"
         "stack.append(index(lhs, [rhs, None], ctx))\n",
         2,


### PR DESCRIPTION
Fixes #1128 