### PR TITLE
Rearrange `kP` and add `kQ`

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -2163,9 +2163,14 @@ Hello World
 string.punctuation (Punctuations)
 
 -------------------------------
-## `` kP `` (Printable ASCII)
+## `` kP `` (Printable ASCII Without Space)
 
-printable ascii
+printable ascii exluding space
+
+-------------------------------
+## `` kQ `` (Printable ASCII With Space)
+
+printable ascii with space
 
 -------------------------------
 ## `` kw `` (ASCII Whitespace)

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1866,9 +1866,14 @@ kp (Punctuation)
 - string.punctuation (Punctuations)
 
 -------------------------------
-kP (Printable ASCII)
+kP (Printable ASCII Without Space)
 
-- printable ascii
+- printable ascii exluding space
+
+-------------------------------
+kQ (Printable ASCII With Space)
+
+- printable ascii with space
 
 -------------------------------
 kw (ASCII Whitespace)

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -3228,12 +3228,20 @@
       - "[] : string.punctuation"
 
 - element: "kP"
-  name: Printable ASCII
+  name: Printable ASCII Without Space
   arity: 0
-  description: printable ascii
+  description: printable ascii exluding space
   vectorise: false
   tests:
-      - "[] : '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&\\'()*+,-./:;<=>?@[\\\\]^_`{|}~'"
+      - "[] : '!\"#$%&\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'"
+
+- element: "kQ"
+  name: Printable ASCII With Space
+  arity: 0
+  description: printable ascii with space
+  vectorise: false
+  tests:
+      - "[] : ' !\"#$%&\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'"
 
 - element: "kw"
   name: ASCII Whitespace

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -1024,8 +1024,8 @@ var codepage_descriptions =
       "token": "P"
     },
     {
-      "name": "Printable ASCII",
-      "description": "printable ascii",
+      "name": "Printable ASCII Without Space",
+      "description": "printable ascii exluding space",
       "token": "kP"
     },
     {
@@ -1046,6 +1046,11 @@ var codepage_descriptions =
       "name": "Quit",
       "description": "Quit the program",
       "token": "Q"
+    },
+    {
+      "name": "Printable ASCII With Space",
+      "description": "printable ascii with space",
+      "token": "kQ"
     },
     {
       "name": "General Quadratic Solver",

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -18446,16 +18446,39 @@ def test_Punctuation():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-def test_PrintableASCII():
+def test_PrintableASCIIWithoutSpace():
 
     stack = [vyxalify(item) for item in []]
-    expected = vyxalify('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~')
+    expected = vyxalify('!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')
     ctx = Context()
 
     ctx.stacks.append(stack)
 
     code = transpile('kP')
     # print('kP', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+def test_PrintableASCIIWithSpace():
+
+    stack = [vyxalify(item) for item in []]
+    expected = vyxalify(' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~')
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('kQ')
+    # print('kQ', code)
     exec(code)
 
     ctx.stacks.pop()

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -6706,8 +6706,11 @@ elements: dict[str, tuple[str, int]] = {
     "ko": process_element('"01234567"', 0),
     "kp": process_element("string.punctuation", 0),
     "kP": process_element(
-        '"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        '!\\"#$%&\\\'()*+,-./:;<=>?@[\\\\]^_`{|}~"',
+        '"!\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"',
+        0,
+    ),
+    "kQ": process_element(
+        '" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"',
         0,
     ),
     "kw": process_element('" \\t\\n\\r\\u000b\\u000c"', 0),


### PR DESCRIPTION
Made `kP` return ASCII characters in the proper order (without a space just as it was) and added `kQ` for all ASCII characters *including* a space.