### PR TITLE
Fix linting issues with nonlocals

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -29,6 +29,8 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics \
+          --exclude .git,build,dist
         # exit-zero treats all errors as warnings.
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 \
+          --statistics --exclude .git,build,dist

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3192,6 +3192,7 @@ def multiset_intersection(lhs, rhs, ctx):
 
     @lazylist_from(lhs)
     def gen():
+        nonlocal rhs
         for item in lhs:
             if item in rhs:
                 yield item
@@ -3873,11 +3874,10 @@ def powerset(lhs, ctx):
     """Element ṗ
     (any) -> powerset of a
     """
+    lhs = iterable(lhs, ctx=ctx)
 
     @lazylist_from(lhs)
     def gen():
-        nonlocal lhs
-        lhs = iterable(lhs, ctx=ctx)
         it = iter(lhs)
 
         prev_sets = [[]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3187,13 +3187,11 @@ def multiset_intersection(lhs, rhs, ctx):
     """Element Þ∩
     (lst, lst) -> Return the multi-set intersection of two lists
     """
+    lhs = iterable(lhs, ctx=ctx)
+    rhs = deep_copy(iterable(rhs, ctx=ctx))
 
     @lazylist_from(lhs)
     def gen():
-        nonlocal rhs
-        lhs = iterable(lhs, ctx=ctx)
-        rhs = deep_copy(iterable(rhs, ctx=ctx))
-
         for item in lhs:
             if item in rhs:
                 yield item

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -141,10 +141,10 @@ def digits(num: NUMBER_TYPE) -> List[int]:
 
 
 def drop_while(vec, fun, ctx):
+    vec = iterable(vec, ctx=ctx)
+
     @lazylist_from(vec)
     def gen():
-        nonlocal vec
-        vec = iterable(vec, ctx=ctx)
         t = True
         for item in vec:
             if not safe_apply(fun, item, ctx=ctx):
@@ -890,11 +890,11 @@ def scanl(
 ) -> List[Any]:
     """Cumulative reduction of vector by function"""
 
+    vector = iterable(vector, ctx=ctx)
+
     @lazylist_from(vector)
     def gen():
-        nonlocal vector
         working = None
-        vector = iterable(vector, ctx=ctx)
         for item in vector:
             if working is None:
                 working = item
@@ -953,11 +953,9 @@ def suffixes(lhs: VyIterable, ctx: Context) -> VyList:
     if isinstance(lhs, str):
         return [lhs[-i:] for i in range(len(lhs), 0, -1)]
 
-    lst = iterable(lhs, ctx=ctx)
-
     @lazylist_from(lhs)
     def gen():
-        nonlocal lst
+        lst = iterable(lhs, ctx=ctx)
         while lst:
             yield lst
             lst = lst[1:]


### PR DESCRIPTION
Lifted iterablification of nonlocal variables up in `multiset_intersection` and a few other places. Added a `nonlocal rhs` to the `gen` function inside `multiset_intersection` because `rhs` has to be mutated inside it.

Also modified the linter workflow to exclude `build`, `dist`, and `.git`