### PR TITLE
Make `i` modular slice strings

### DIFF
--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1199,7 +1199,9 @@
       any-[x,y,m]: a[x:y:m] (x to yth item of a, taking every mth)
   vectorise: false
   tests:
-      - '["abc",[1,2]] : "b"'
+      - '["abc", [1,2]] : "b"'
+      - '["abc", 3] : "a"'
+      - "[[1, 2, 3], [4, 9]] : [2, 3, 1, 2, 3]"
       - '["joemama","biden''s"] : "joebiden''smama"'
       - "[[1,2,3], 0] : 1"
       - "[[1,2,3], -1] : 3"
@@ -2487,6 +2489,7 @@
       - "[123,2] : 12"
       - '["abc","."] : ["a","b","c"]'
       - '["abc","d"] : []'
+      - '["abc", 9] : "abcabcabc"'
 
 - element: "Ż"
   name: Slice From One Until
@@ -2503,6 +2506,7 @@
       - "[123,3] : 23"
       - '["abc","."] : []'
       - '["abc","d"] : []'
+      - '["abc", 9] : "bcabcabc"'
 
 - modifier: "₌"
   name: Parallel Apply

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -6710,8 +6710,50 @@ def test_Head():
 
 def test_Index():
 
-    stack = [vyxalify(item) for item in ["abc",[1,2]]]
+    stack = [vyxalify(item) for item in ["abc", [1,2]]]
     expected = vyxalify("b")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('i')
+    # print('i', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abc", 3]]
+    expected = vyxalify("a")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('i')
+    # print('i', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [[1, 2, 3], [4, 9]]]
+    expected = vyxalify([2, 3, 1, 2, 3])
     ctx = Context()
 
     ctx.stacks.append(stack)
@@ -15297,6 +15339,27 @@ def test_SliceUntil():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
+    stack = [vyxalify(item) for item in ["abc", 9]]
+    expected = vyxalify("abcabcabc")
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ẏ')
+    # print('Ẏ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
 def test_SliceFromOneUntil():
 
     stack = [vyxalify(item) for item in ["abc",2]]
@@ -15385,6 +15448,27 @@ def test_SliceFromOneUntil():
 
     stack = [vyxalify(item) for item in ["abc","d"]]
     expected = vyxalify([])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ż')
+    # print('Ż', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ["abc", 9]]
+    expected = vyxalify("bcabcabc")
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -2089,9 +2089,15 @@ def index(lhs, rhs, ctx):
 
     else:
         assert len(rhs) <= 3
-        return lhs[
+        originally_string = type(lhs) is str
+        if originally_string:
+            lhs = LazyList(list(lhs))
+
+        temp = lhs[
             slice(*[None if vy_type(v) != NUMBER_TYPE else int(v) for v in rhs])
         ]
+
+        return "".join(temp) if originally_string else temp
 
 
 def index_indices_or_cycle(lhs, rhs, ctx):


### PR DESCRIPTION
Fixes #1287

Plus:

add more tests for `i`
add more tests for `Ẏ`
add more tests for `Ż`