### PR TITLE
Special case two-lists in prepend again

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3865,10 +3865,12 @@ def prepend(lhs, rhs, ctx):
     """Element p
     (any, any) -> a.prepend(b) (Prepend b to a)
     """
-    ts = vy_type(lhs, rhs)
-    return {(ts[0], ts[1]): lambda: merge(rhs, lhs, ctx=ctx)}.get(
-        ts, lambda: [rhs] + lhs
-    )()
+
+    ts = vy_type(lhs, rhs, simple=True)
+    if ts != (list, list):
+        return merge(rhs, lhs, ctx)
+    else:
+        return [rhs] + lhs
 
 
 def prev_prime(lhs, ctx):


### PR DESCRIPTION
For some reason, the type dictionary was changed to never consider `list, list` to be a special case.

No linked issue, just a test that stopped passing.