### PR TITLE
Fix `ø⟇`

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -875,7 +875,7 @@ def codepage_digraph(lhs, ctx):
         (NUMBER_TYPE): lambda: vyxal.encoding.codepage[int(lhs)],
         (str): lambda: vyxal.encoding.codepage.find(lhs)
         if len(lhs) <= 1
-        else vectorise(codepage_digraph, lhs, ctx=ctx),
+        else vectorise(codepage_digraph, list(lhs), ctx=ctx),
     }.get(ts, lambda: vectorise(codepage_digraph, lhs, ctx=ctx))()
 
 


### PR DESCRIPTION
No linked issue, just seems to be vectorising stuff over strings.

/shrug