### PR TITLE
Add overloads for vectorising sum

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1594,10 +1594,15 @@ Reverse a value
 
 - any a: `reversed(a)`
 -------------------------------
-## `` Ṡ `` (Vectorised sums)
+## `` Ṡ `` (Vectorised sums / Strip whitespace from both sides / Is positive)
 
 Sum of each item in a list
 
+### Overloads
+
+- lst a: `vectorising_sum(a)`
+- str a: `a.strip()`
+- num a: `is_positive(a)`
 -------------------------------
 ## `` Ṫ `` (Tail Remove / Truthy Under)
 

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1361,10 +1361,13 @@ z (Zip-self)
 
     any a: reversed(a)
 -------------------------------
-Ṡ (Vectorised sums)
+Ṡ (Vectorised sums / Strip whitespace from both sides / Is positive)
 
 - Sum of each item in a list
 
+    lst a: vectorising_sum(a)
+    str a: a.strip()
+    num a: is_positive(a)
 -------------------------------
 Ṫ (Tail Remove / Truthy Under)
 

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -2422,13 +2422,22 @@
       - "[[1, 2, 3, 4]] : [4, 3, 2, 1]"
 
 - element: "Ṡ"
-  name: Vectorised sums
+  name: Vectorised sums / Strip whitespace from both sides / Is positive
   description: Sum of each item in a list
-  arity: 0
+  arity: 1
+  overloads:
+      lst: vectorising_sum(a)
+      str: a.strip()
+      num: is_positive(a)
   tests:
-      - "[[[1,2,3],[4,5,6]]] : [6, 15]"
-      - "[[3,4,5]] : [3, 4, 5]"
-      - "[[[1,2,3], [1, 2, 3, 4]]] : [6, 10]"
+      - "[[[1 ,2, 3], [4, 5, 6]]] : [6, 15]"
+      - "[[3, 4, 5]] : [3, 4, 5]"
+      - "[[[1, 2, 3], [1, 2, 3, 4]]] : [6, 10]"
+      - "[' abc  '] : 'abc'"
+      - "['abc     '] : 'abc'"
+      - "[3] : 1"
+      - "[0] : 0"
+      - "[-5] : 0"
 
 - element: "Ṫ"
   name: Tail Remove / Truthy Under

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2882,8 +2882,9 @@ var codepage_descriptions =
   ],
   "198": [
     {
-      "name": "Vectorised sums",
+      "name": "Vectorised sums / Strip whitespace from both sides / Is positive",
       "description": "Sum of each item in a list",
+      "overloads": "lst -> vectorising_sum(a)\nstr -> a.strip()\nnum -> is_positive(a)",
       "token": "\u1e60"
     },
     {

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -14930,9 +14930,9 @@ def test_Reverse():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-def test_Vectorisedsums():
+def test_VectorisedsumsStripwhitespacefrombothsidesIspositive():
 
-    stack = [vyxalify(item) for item in [[[1,2,3],[4,5,6]]]]
+    stack = [vyxalify(item) for item in [[[1 ,2, 3], [4, 5, 6]]]]
     expected = vyxalify([6, 15])
     ctx = Context()
 
@@ -14953,7 +14953,7 @@ def test_Vectorisedsums():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [[3,4,5]]]
+    stack = [vyxalify(item) for item in [[3, 4, 5]]]
     expected = vyxalify([3, 4, 5])
     ctx = Context()
 
@@ -14974,8 +14974,113 @@ def test_Vectorisedsums():
         assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
 
 
-    stack = [vyxalify(item) for item in [[[1,2,3], [1, 2, 3, 4]]]]
+    stack = [vyxalify(item) for item in [[[1, 2, 3], [1, 2, 3, 4]]]]
     expected = vyxalify([6, 10])
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ṡ')
+    # print('Ṡ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [' abc  ']]
+    expected = vyxalify('abc')
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ṡ')
+    # print('Ṡ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in ['abc     ']]
+    expected = vyxalify('abc')
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ṡ')
+    # print('Ṡ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [3]]
+    expected = vyxalify(1)
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ṡ')
+    # print('Ṡ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [0]]
+    expected = vyxalify(0)
+    ctx = Context()
+
+    ctx.stacks.append(stack)
+
+    code = transpile('Ṡ')
+    # print('Ṡ', code)
+    exec(code)
+
+    ctx.stacks.pop()
+    actual = vyxalify(stack[-1])
+
+    print(simplify(expected), simplify(actual))
+
+    if vy_type(actual, simple=True) is list or vy_type(expected, simple=True) is list:
+        assert all(deep_flatten(equals(actual, expected, ctx), ctx)) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+    else:
+        assert equals(actual, expected, ctx) or non_vectorising_equals(actual, expected, ctx), "Expected " + str(expected) + ", got " + str(simplify(actual))
+
+
+    stack = [vyxalify(item) for item in [-5]]
+    expected = vyxalify(0)
     ctx = Context()
 
     ctx.stacks.append(stack)

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5492,11 +5492,18 @@ def vectorised_not(lhs, ctx):
 
 def vectorised_sum(lhs, ctx):
     """Element Ṡ
-    (any) -> the equivalent of v∑
+    (lst) -> the equivalent of v∑
+    (str) -> strip whitespace from both sides
+    (num) -> is positive
     """
-    return LazyList(
-        vy_sum(iterable(x, ctx=ctx), ctx) for x in iterable(lhs, ctx=ctx)
-    )
+    ts = vy_type(lhs, simple=True)
+    return {
+        list: lambda: LazyList(
+            vy_sum(iterable(x, ctx=ctx), ctx) for x in iterable(lhs, ctx=ctx)
+        ),
+        str: lambda: vy_str(lhs, ctx=ctx).strip(),
+        NUMBER_TYPE: lambda: 1 if lhs > 0 else 0
+    }.get(ts)()
 
 
 def vertical_join(lhs, rhs=" ", ctx=None):

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5502,7 +5502,7 @@ def vectorised_sum(lhs, ctx):
             vy_sum(iterable(x, ctx=ctx), ctx) for x in iterable(lhs, ctx=ctx)
         ),
         str: lambda: vy_str(lhs, ctx=ctx).strip(),
-        NUMBER_TYPE: lambda: 1 if lhs > 0 else 0
+        NUMBER_TYPE: lambda: 1 if lhs > 0 else 0,
     }.get(ts)()
 
 


### PR DESCRIPTION
The `str` overload is strip white space from both sides just like `øS`, and the `num` overload checks if a number is positive.