### PR TITLE
Make Ǒ return -1 if not found

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -242,6 +242,14 @@ def test_vectorised_lambda_multiplication():
     assert stack[-1] == [3, 6, 2, 3, 6, 3, 5, 1]
 
 
+def test_find_first_truthy_under_function():
+    stack = run_vyxal("⟨ 3 | 7 | 2 | 8 | 5 ⟩ ⁽₅ Ǒ")
+    assert stack[-1] == 4
+
+    stack = run_vyxal("⟨ 3 | 7 | 2 | 8 ⟩ ⁽₅ Ǒ")
+    assert stack[-1] == -1
+
+
 def test_powerset_inf():
     stack = run_vyxal("⁽› 1 Ḟ ṗ", debug=True)
     assert stack[-1][:4] == [[], [1], [2], [1, 2]]

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3361,7 +3361,8 @@ def multiplicity(lhs, rhs, ctx):
     elif ts == (str, str):
         return remove_until_no_change(lhs, rhs, ctx)
     elif types.FunctionType in ts:
-        return find(lhs, rhs, ctx)[0]
+        temp = find(lhs, rhs, ctx)
+        return temp[0] if temp else -1
     else:
         return vectorise(multiplicity, lhs, rhs, ctx=ctx)
 


### PR DESCRIPTION
It previously returned `0`, which isn't helpful, given that the first truthy item may also be at index `0`.