### PR TITLE
Assorted changes

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,8 +1,6 @@
 name: Test and upload jar
 
 on:
-  push:
-    branches: ['*']
   pull_request:
     branches: [ version-3 ]
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -2,7 +2,7 @@ name: Test and upload jar
 
 on:
   push:
-    branches: [ version-3 ]
+    branches: ['*']
   pull_request:
     branches: [ version-3 ]
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+RUN sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/Ammonite/releases/download/2.0.4/2.13-2.0.4) > /usr/local/bin/amm && chmod +x /usr/local/bin/amm'
+
+RUN brew install scala coursier/formulas/coursier sbt

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+
+image:
+  file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - scala-lang.scala
+    - scalameta.metals

--- a/shared/src/main/scala/AST.scala
+++ b/shared/src/main/scala/AST.scala
@@ -9,7 +9,7 @@ enum AST {
   /** Multiple ASTs grouped into one list */
   case Group(elems: List[AST])
   case SpecialModifier(modi: String, value: String)
-  case CompositeNilad(elem: List[AST])
+  case CompositeNilad(elems: List[AST])
 
   /** The result of applying a modifier to some arguments. `res` can be applied
     * directly to the stack.
@@ -37,6 +37,7 @@ enum AST {
     case Command(value) => value
     case Group(elems)   => elems.map(_.toVyxal).mkString
     case SpecialModifier(modi, value) => s"$modi$value"
+    case CompositeNilad(elems)        => elems.map(_.toVyxal).mkString
     case CompressedString(value)      => s"\"$value“"
     case CompressedNumber(value)      => s"\"$value„"
     case DictionaryString(value)      => s"\"$value”"
@@ -47,6 +48,7 @@ enum AST {
     case FnDef(name, lam)            => ???
     case GetVar(name)                => s"#<$name"
     case SetVar(name)                => s"#>$name"
+    case ast                         => ast.toString
   }
 }
 

--- a/shared/src/main/scala/Context.scala
+++ b/shared/src/main/scala/Context.scala
@@ -232,6 +232,10 @@ object Context {
   /** Make a new Context for a function that was defined inside `origCtx` but is
     * now executing inside `currCtx`
     *
+    * @param origCtx
+    *   The context in which the function was defined
+    * @param currCtx
+    *   The context where the function is currently executing
     * @param popArgs
     *   Whether the inputs for the function will be popped from the stack
     *   (instead of merely peeking)
@@ -241,9 +245,12 @@ object Context {
       currCtx: Context,
       arity: Int,
       params: List[String],
+      args: Option[Seq[VAny]],
       popArgs: Boolean
   ) = {
-    val newInputs = if (popArgs) currCtx.pop(arity) else currCtx.peek(arity)
+    val newInputs = args
+      .map(_.toList)
+      .getOrElse(if (popArgs) currCtx.pop(arity) else currCtx.peek(arity))
     if (currCtx.settings.logLevel == LogLevel.Debug) {
       println(
         s"newInputs = $newInputs, arity = $arity, stack = ${currCtx.stack}, popArgs = $popArgs"

--- a/shared/src/main/scala/FuncHelpers.scala
+++ b/shared/src/main/scala/FuncHelpers.scala
@@ -1,7 +1,20 @@
 package vyxal
 
+import vyxal.impls.UnimplementedOverloadException
+
 /** Helpers for function-related stuff */
 object FuncHelpers {
+
+  /** Take a monad, dyad, or triad, and return a proper (not Partial) function
+    * that errors if it's not defined for the input
+    */
+  def errorIfUndefined[T](
+      name: String,
+      fn: Context ?=> PartialFunction[T, VAny]
+  ): T => Context ?=> VAny = args =>
+    if (fn.isDefinedAt(args)) fn(args)
+    else throw UnimplementedOverloadException(name, args)
+
   def vectorise(fn: VFun)(using ctx: Context): Unit = {
     if (fn.arity == 1) {
       ctx.push(vectorise1(fn))

--- a/shared/src/main/scala/Interpreter.scala
+++ b/shared/src/main/scala/Interpreter.scala
@@ -40,7 +40,9 @@ object Interpreter {
           case None       => throw RuntimeException(s"No such command: '$cmd'")
         }
       case AST.Group(elems) =>
-        elems.foreach { elem => Interpreter.execute(elem) }
+        elems.foreach(Interpreter.execute(_))
+      case AST.CompositeNilad(elems) =>
+        elems.foreach(Interpreter.execute(_))
       case AST.Modified(fn) => fn()
       case AST.If(thenBody, elseBody) =>
         if (MiscHelpers.boolify(ctx.pop())) {

--- a/shared/src/main/scala/ListHelpers.scala
+++ b/shared/src/main/scala/ListHelpers.scala
@@ -1,5 +1,7 @@
 package vyxal
 
+import collection.mutable.ArrayBuffer
+
 object ListHelpers {
 
   /** Make an iterable from a value
@@ -43,24 +45,24 @@ object ListHelpers {
     */
   def mold(content: VList, shape: VList)(using ctx: Context): VList = {
     def moldHelper(content: VList, shape: VList, ind: Int): VList = {
-      var output: List[VAny] = List()
-      var mutContent = content
-      var mutShape = shape.toList
+      val output = ArrayBuffer.empty[VAny]
+      val mutContent = content
+      val mutShape = shape.toList
       var index = ind
       for item <- mutShape do {
         item match {
           case item: VList =>
-            output = output :+ (moldHelper(mutContent, item, index))
+            output += moldHelper(mutContent, item, index)
             output.last match {
               case list: VList => index += list.length - 1
               case _           => index += 1
             }
-          case item: VAny => output = output :+ mutContent(index)
+          case item: VAny => output += mutContent(index)
         }
         index += 1
       }
 
-      VList(output*)
+      VList(output.toSeq*)
     }
     moldHelper(content, shape, 0)
   }
@@ -76,7 +78,7 @@ object ListHelpers {
     *   list, the last element of the returned sequence will be an empty list.
     */
   def split[T](list: Seq[T], sep: Seq[T]): Seq[Seq[T]] = {
-    val parts = collection.mutable.ArrayBuffer.empty[Seq[T]]
+    val parts = ArrayBuffer.empty[Seq[T]]
 
     var lastInd = 0
     var sliceInd = list.indexOfSlice(sep)

--- a/shared/src/main/scala/ListHelpers.scala
+++ b/shared/src/main/scala/ListHelpers.scala
@@ -35,6 +35,12 @@ object ListHelpers {
         }
     }
 
+  def map(f: VFun, to: VList)(using ctx: Context): VList = {
+    VList(to.zipWithIndex.map { (item, index) =>
+      f.execute(index, item, List(item))
+    }*)
+  }
+
   /** Mold a list into a shape.
     * @param content
     *   The list to mold.

--- a/shared/src/main/scala/MiscHelpers.scala
+++ b/shared/src/main/scala/MiscHelpers.scala
@@ -4,12 +4,12 @@ import vyxal.Interpreter.executeFn
 
 object MiscHelpers {
   // todo consider doing something like APL's forks so this doesn't have to be a partial function
-  val add: VyFn[2] = forkify("add") {
+  val add: VyFn[2] = vect2(forkify("add") {
     case (a: VNum, b: VNum)     => a + b
     case (a: String, b: VNum)   => s"$a$b"
     case (a: VNum, b: String)   => s"$a$b"
     case (a: String, b: String) => s"$a$b"
-  }
+  })
 
   def boolify(x: VAny) = x match {
     case n: VNum   => n != 0
@@ -38,58 +38,50 @@ object MiscHelpers {
     ???
   }
 
-  def map(f: VFun, to: VList)(using ctx: Context): VList = {
-    val result = to.toList.zipWithIndex.map { case (item, index) =>
-      val mapCtx = Context.makeFnCtx(ctx, f.ctx, f.arity, f.params, true)
-      mapCtx.contextVarM = index
-      mapCtx.contextVarN = item
-      f(item)(using mapCtx)
-    }.toList
-    VList(result*)
-  }
-
-  def multiply(a: VAny, b: VAny)(using Context): VAny = (a, b) match {
-    case (a: VNum, b: VNum)     => a * b
-    case (a: String, b: VNum)   => a * b.toInt
-    case (a: VNum, b: String)   => b * a.toInt
-    case (a: String, b: String) => StringHelpers.ringTranslate(a, b)
-    case (a: VFun, b: VNum)     => a.withArity(b.toInt)
-  }
+  val multiply: VyFn[2] = vect2(
+    FuncHelpers.errorIfUndefined(
+      "multiply",
+      {
+        case (a: VNum, b: VNum)     => a * b
+        case (a: String, b: VNum)   => a * b.toInt
+        case (a: VNum, b: String)   => b * a.toInt
+        case (a: String, b: String) => StringHelpers.ringTranslate(a, b)
+        case (a: VFun, b: VNum)     => a.withArity(b.toInt)
+      }
+    )
+  )
 
   def reduce(iter: VAny, by: VFun, init: Option[VAny] = None)(using
       ctx: Context
   ): VAny = {
-    var remaining = ListHelpers.makeIterable(iter, Some(true))(using ctx)
+    var remaining = ListHelpers.makeIterable(iter, Some(true))(using ctx).toList
 
     // Convert niladic + monadic functions to be dyadic for reduction purposes
     val byFun = by.withArity(if (by.arity < 2) 2 else by.arity)
 
     // Take the first byFun.arity items as the initial set to operate on
     var operating = init match {
-      case Some(elem) => elem +: remaining.take(byFun.arity - 1).toList
-      case None       => remaining.take(byFun.arity).toList
+      case Some(elem) => elem +: remaining.take(byFun.arity - 1)
+      case None       => remaining.take(byFun.arity)
     }
     remaining = remaining.drop(operating.length)
-
-    val reduceCtx =
-      Context.makeFnCtx(ctx, byFun.ctx, byFun.arity, byFun.params, true)
 
     if (operating.length == 0) { return 0 }
     if (operating.length == 1) { return operating.head }
 
-    reduceCtx.contextVarN = operating(0)
-    reduceCtx.contextVarM = operating(1)
+    var contextVarN = operating(0)
+    var contextVarM = operating(1)
 
     while remaining.length + operating.length != 1 do {
-      val result = byFun(operating)(using reduceCtx)
-      reduceCtx.contextVarM = remaining.headOption.getOrElse(result)
-      reduceCtx.contextVarN = result
-      println(s"m: ${reduceCtx.contextVarM}, n: ${reduceCtx.contextVarN}")
-      operating = (result +: remaining.take(byFun.arity - 1)).toList
+      val result = byFun.execute(contextVarM, contextVarN, operating)
+      contextVarM = remaining.headOption.getOrElse(result)
+      contextVarN = result
+      println(s"m: ${contextVarM}, n: ${contextVarN}")
+      operating = result +: remaining.take(byFun.arity - 1)
       remaining = remaining.drop(byFun.arity - 1)
     }
 
-    reduceCtx.contextVarN
+    contextVarN
   }
 
   def vyPrint(x: VAny)(using ctx: Context): Unit = {

--- a/shared/src/main/scala/StringHelpers.scala
+++ b/shared/src/main/scala/StringHelpers.scala
@@ -1,9 +1,11 @@
 package vyxal
 
+import collection.mutable.StringBuilder
+
 object StringHelpers {
 
   def formatString(fmtstr: String, args: AnyRef*): String = {
-    val sb = new collection.mutable.StringBuilder()
+    val sb = StringBuilder()
     var i = 0
     var j = 0
     while (i < fmtstr.length) {

--- a/shared/src/main/scala/VAny.scala
+++ b/shared/src/main/scala/VAny.scala
@@ -32,39 +32,20 @@ case class VFun(
   /** Make a copy of this function with a different arity. */
   def withArity(newArity: Int): VFun = this.copy(arity = newArity)
 
-  def apply(args: List[VAny], customContext: Option[Context] = None)(using
-      ctx: Context
-  ): VAny = {
-
-    // Good for functions which need to set context variable M
-
-    val innerCtx = customContext.getOrElse(
-      Context.makeFnCtx(this.ctx, ctx, arity, params, true)
+  /** Call this function on the given arguments, using custom context variables.
+    */
+  def execute(
+    contextVarM: VAny, contextVarN: VAny, args: Seq[VAny]
+  )(using ctx: Context): VAny =
+    Interpreter.executeFn(
+      this,
+      Some(contextVarM),
+      Some(contextVarN),
+      Some(args)
     )
-    for (arg <- args) {
-      innerCtx.push(arg)
-    }
 
-    impl()(using innerCtx)
-
-    if (innerCtx.isStackEmpty) ctx.settings.defaultValue
-    else innerCtx.pop()
-
-  }
-
-  def apply(args: VAny*)(using ctx: Context): VAny = {
-    val innerCtx = Context.makeFnCtx(this.ctx, ctx, arity, params, true)
-
-    for (arg <- args) {
-      innerCtx.push(arg)
-    }
-
-    impl()(using innerCtx)
-
-    if (innerCtx.isStackEmpty) ctx.settings.defaultValue
-    else innerCtx.pop()
-  }
-
+  def apply(args: VAny*)(using ctx: Context): VAny =
+    Interpreter.executeFn(this)
 }
 
 object VFun {

--- a/shared/src/main/scala/VList.scala
+++ b/shared/src/main/scala/VList.scala
@@ -34,7 +34,17 @@ class VList private (val lst: Seq[VAny])
 
   /** Get the element at index `ind`
     */
-  override def apply(ind: Int): VAny = lst(ind)
+  override def apply(ind: Int): VAny =
+    if (ind < 0) {
+      // floorMod because % gives negative results with negative dividends
+      lst(Math.floorMod(ind, lst.length))
+    } else {
+      try {
+        lst(ind)
+      } catch {
+        case _: IndexOutOfBoundsException => lst(ind % lst.length)
+      }
+    }
 
   override def iterator: Iterator[VAny] = lst.iterator
 

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -61,4 +61,21 @@ class ElementTests extends AnyFunSpec {
       }
     }
   }
+
+  describe("Element R") {
+    describe("when given function and iterable") {
+      it("should work with singleton lists") {
+        given ctx: Context = Context()
+        assertResult(1: VNum)(
+          Impls.reduction(VList(1), VFun(Elements.elements("+").impl, 2, List.empty, ctx))
+        )
+      }
+      it("should calculate sum properly") {
+        given ctx: Context = Context()
+        assertResult(15: VNum)(
+          Impls.reduction(VNum(5), VFun(Elements.elements("+").impl, 2, List.empty, ctx))
+        )
+      }
+    }
+  }
 }

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -25,7 +25,8 @@ class ElementTests extends AnyFunSpec {
     }
     describe("when given functions") {
       it("should turn two functions into an fgh fork") {
-        given ctx: Context = Context(settings = Settings(logLevel = LogLevel.Debug))
+        given ctx: Context =
+          Context(settings = Settings(logLevel = LogLevel.Debug))
         // Factorial
         val f = VFun.fromElement(Elements.elements("!"))
         // Function to subtract 8
@@ -41,6 +42,22 @@ class ElementTests extends AnyFunSpec {
         println(s"Made fork, executing function")
         Interpreter.execute(AST.ExecuteFn)
         assertResult(VNum(1))(ctx.pop())
+      }
+    }
+  }
+
+  describe("Element M") {
+    describe("when given two lists") {
+      it("should mold them properly") {
+        given Context = Context()
+        assertResult(
+          VList(1, 2, VList(VList(VList(3, 4), 5, 1), 2))
+        )(
+          Impls.mapElement(
+            VList(1, 2, VList(3, 4), 5),
+            VList(1, 2, VList(VList(3, 4, 6), 5))
+          )
+        )
       }
     }
   }

--- a/shared/src/test/scala/ParserTests.scala
+++ b/shared/src/test/scala/ParserTests.scala
@@ -55,6 +55,7 @@ class ParserTests extends AnyFunSuite {
       VyxalParser.parse("1 { 2 | { {3 | 4} | } } 6") ===
         Right(
           AST.makeSingle(
+            Number(6),
             Number(1),
             AST.While(
               Some(Number(2)),
@@ -67,8 +68,7 @@ class ParserTests extends AnyFunSuite {
                 ),
                 AST.makeSingle()
               )
-            ),
-            Number(6)
+            )
           )
         )
     )
@@ -79,6 +79,7 @@ class ParserTests extends AnyFunSuite {
       VyxalParser.parse("1 { 2 | { {3 | 4} | ] 6") ===
         Right(
           AST.makeSingle(
+            Number(6),
             Number(1),
             AST.While(
               Some(Number(2)),
@@ -91,8 +92,7 @@ class ParserTests extends AnyFunSuite {
                 ),
                 AST.makeSingle()
               )
-            ),
-            Number(6)
+            )
           )
         )
     )


### PR DESCRIPTION
Sorry, this PR is a bunch of unrelated changes:
- Made the code a little more idiomatic in places
- Fix parser tests with trailing nilad moving to front, add simple tests for specific cases of reduce and mold
- Vectorise the add and multiply helpers themselves instead of the element in `Impls`
- Allow setting context vars in `Interpreter.executeFn`, use that for executing `VFun`s
- Get the test-build Github Actions workflow to run on pushes to all branches instead of just version-3