### PR TITLE
Modify Scalafmt to rewrite to new syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,18 @@
-version = "3.5.3"
+version = "3.6.1"
 runner.dialect = scala3
 
 align.preset = some
 maxColumn = 80
 
 docstrings.oneline = fold
+
+rewrite.scala3.convertToNewSyntax = yes
+rewrite.scala3.removeOptionalBraces = yes
+# Insert an end marker if a function/class/whatever is longer than 15 lines
+rewrite.scala3.insertEndMarkerMinLines = 15
+
+rewrite.rules = [Imports]
+rewrite.imports.sort = original
+# Any Vyxal imports go at the top
+rewrite.imports.groups = [["vyxal\\..*"]]
+rewrite.imports.contiguousGroups = no

--- a/jvm/src/main/scala/Main.scala
+++ b/jvm/src/main/scala/Main.scala
@@ -1,9 +1,8 @@
 package vyxal
 
-import vyxal.impls.{Elements, Element}
+import vyxal.impls.{Element, Elements}
 
 import java.io.File
-
 import scopt.OParser
 
 /** Configuration for the command line argument parser
@@ -28,47 +27,39 @@ case class CLIConfig(
     settings: Settings = Settings()
 )
 
-object Main {
-  def main(args: Array[String]): Unit = {
-    OParser.parse(parser, args, CLIConfig()) match {
+object Main:
+  def main(args: Array[String]): Unit =
+    OParser.parse(parser, args, CLIConfig()) match
       case Some(config) =>
         given Context = Context(
           config.inputs.reverse.map(Parser.parseInput)
         )
 
-        if (config.printHelp) {
+        if config.printHelp then
           println(OParser.usage(parser))
           return
-        }
 
-        if (config.printDocs) {
+        if config.printDocs then
           printDocs()
           return
-        }
 
         config.file.foreach { file =>
           val source = io.Source.fromFile(config.file.get)
-          try {
+          try
             Interpreter.execute(source.mkString)
-          } finally {
+          finally
             source.close()
-          }
         }
 
         config.code.foreach { code =>
           Interpreter.execute(code)
         }
 
-        if (config.file.nonEmpty || config.code.nonEmpty) {
-          return
-        } else {
-          Repl.startRepl()
-        }
+        if config.file.nonEmpty || config.code.nonEmpty then return
+        else Repl.startRepl()
       case None => ???
-    }
-  }
 
-  private def printDocs(): Unit = {
+  private def printDocs(): Unit =
     Elements.elements.values.foreach {
       case Element(
             symbol,
@@ -80,18 +71,17 @@ object Main {
             impl
           ) =>
         print(
-          s"$symbol ($name) (${if (vectorises) "" else "non-"}vectorising)\n"
+          s"$symbol ($name) (${if vectorises then "" else "non-"}vectorising)\n"
         )
         overloads.foreach { overload =>
           println(s"- $overload")
         }
         println("---------------------")
     }
-  }
 
   private val builder = OParser.builder[CLIConfig]
 
-  private val parser = {
+  private val parser =
     import builder.*
 
     def flag(short: Char, name: String, text: String) =
@@ -256,5 +246,5 @@ object Main {
         "Limit list output to the first 100 items of that list"
       )
     )
-  }
-}
+  end parser
+end Main

--- a/jvm/src/main/scala/Repl.scala
+++ b/jvm/src/main/scala/Repl.scala
@@ -2,13 +2,10 @@ package vyxal
 
 import scala.io.StdIn
 
-object Repl {
-  def startRepl()(using ctx: Context): Unit = {
-    while (true) {
+object Repl:
+  def startRepl()(using ctx: Context): Unit =
+    while true do
       print("> ")
 
       val code = StdIn.readLine()
       Interpreter.execute(code)
-    }
-  }
-}

--- a/shared/src/main/scala/AST.scala
+++ b/shared/src/main/scala/AST.scala
@@ -2,7 +2,7 @@ package vyxal
 
 import vyxal.impls.Elements
 
-enum AST(val arity: Option[Int]) {
+enum AST(val arity: Option[Int]):
   case Number(value: VNum) extends AST(Some(0))
   case Str(value: String) extends AST(Some(0))
   case Lst(elems: List[AST]) extends AST(Some(0))
@@ -37,7 +37,7 @@ enum AST(val arity: Option[Int]) {
   case JunkModifier(name: String, modArity: Int) extends AST(Some(modArity))
 
   /** Generate the Vyxal code this AST represents */
-  def toVyxal: String = this match {
+  def toVyxal: String = this match
     case Number(n)       => n.toString
     case Str(value)      => s"\"$value\""
     case Lst(elems)      => elems.map(_.toVyxal).mkString("#[", "|", "#]")
@@ -57,14 +57,12 @@ enum AST(val arity: Option[Int]) {
     case GetVar(name)                => s"#<$name"
     case SetVar(name)                => s"#>$name"
     case ast                         => ast.toString
-  }
-}
+end AST
 
-object AST {
+object AST:
 
   /** Turn zero or more ASTs into one, wrapping in a [[AST.Group]] if necessary
     */
   def makeSingle(elems: AST*): AST =
-    if (elems.size == 1) elems.head
+    if elems.size == 1 then elems.head
     else AST.Group(elems.toList, None)
-}

--- a/shared/src/main/scala/Context.scala
+++ b/shared/src/main/scala/Context.scala
@@ -1,6 +1,6 @@
 package vyxal
 
-import scala.collection.{mutable => mut}
+import scala.collection.{mutable as mut}
 import scala.collection.mutable.Stack
 import scala.io.StdIn
 
@@ -29,50 +29,38 @@ class Context private (
     private var inputs: Inputs = Inputs(),
     private val parent: Option[Context] = None,
     val globals: Globals = Globals()
-) {
+):
   def settings: Settings = globals.settings
 
-  def pop(): VAny = {
-    val elem = if (stack.nonEmpty) {
-      stack.remove(stack.size - 1)
-    } else if (inputs.nonEmpty) {
-      inputs.next()
-    } else {
-      val temp = StdIn.readLine()
-      if (temp.nonEmpty) {
-        Parser.parseInput(temp)
-      } else {
-        settings.defaultValue
+  def pop(): VAny =
+    val elem =
+      if stack.nonEmpty then stack.remove(stack.size - 1)
+      else if inputs.nonEmpty then inputs.next()
+      else {
+        val temp = StdIn.readLine()
+        if temp.nonEmpty then Parser.parseInput(temp)
+        else settings.defaultValue
       }
-    }
-    if (settings.logLevel == LogLevel.Debug) {
-      println(s"Popped $elem")
-    }
+    if settings.logLevel == LogLevel.Debug then println(s"Popped $elem")
     elem
-  }
 
   /** Pop n elements and wrap in a list */
   def pop(n: Int): List[VAny] = List.fill(n)(this.pop())
 
   /** Get the top element on the stack without popping */
   def peek: VAny =
-    if (stack.nonEmpty) {
-      stack.last
-    } else if (inputs.nonEmpty) {
-      inputs.peek
-    } else {
-      settings.defaultValue
-    }
+    if stack.nonEmpty then stack.last
+    else if inputs.nonEmpty then inputs.peek
+    else settings.defaultValue
 
   /** Get the top n elements on the stack without popping */
-  def peek(n: Int): List[VAny] = {
+  def peek(n: Int): List[VAny] =
     // Number of elements peekable from the stack
     val numStack = n.max(stack.length)
     // Number of elements that need to be taken from the input
     val numInput = n - numStack
     // todo repeat the inputs or something?
     inputs.peek(numInput) ++ stack.slice(stack.length - numStack, stack.length)
-  }
 
   def push(item: VAny): Unit = stack += item
 
@@ -91,9 +79,8 @@ class Context private (
   /** Setter for the context variable so that outsiders don't have to deal with
     * it being an Option
     */
-  def contextVarN_=(newCtx: VAny) = {
+  def contextVarN_=(newCtx: VAny) =
     _contextVarN = Some(newCtx)
-  }
 
   def contextVarM: VAny =
     _contextVarM
@@ -103,9 +90,8 @@ class Context private (
   /** Setter for the context variable so that outsiders don't have to deal with
     * it being an Option
     */
-  def contextVarM_=(newCtx: VAny) = {
+  def contextVarM_=(newCtx: VAny) =
     _contextVarM = Some(newCtx)
-  }
 
   /** Get a variable by the given name. If it doesn't exist in the current
     * context, looks in the parent context. If not found in any context, returns
@@ -123,14 +109,11 @@ class Context private (
     * current context.
     */
   def setVar(name: String, value: VAny): Unit =
-    if (vars.contains(name)) {
-      vars(name) = value
-    } else {
-      Context.findParentWithVar(this, name) match {
+    if vars.contains(name) then vars(name) = value
+    else
+      Context.findParentWithVar(this, name) match
         case Some(parent) => parent.setVar(name, value)
         case None         => vars(name) = value
-      }
-    }
 
   /** Make a new Context for a structure inside the current structure */
   def makeChild() = new Context(
@@ -142,9 +125,9 @@ class Context private (
     Some(this),
     globals
   )
-}
+end Context
 
-object Context {
+object Context:
   def apply(
       inputs: Seq[VAny] = Seq.empty,
       globals: Globals = Globals()
@@ -161,15 +144,11 @@ object Context {
       ctx: Context,
       varName: String
   ): Option[Context] =
-    ctx.parent match {
+    ctx.parent match
       case Some(parent) =>
-        if (parent.vars.contains(varName)) {
-          Some(parent)
-        } else {
-          findParentWithVar(parent, varName)
-        }
+        if parent.vars.contains(varName) then Some(parent)
+        else findParentWithVar(parent, varName)
       case None => None
-    }
 
   /** Make a new Context for a function that was defined inside `origCtx` but is
     * now executing inside `currCtx`
@@ -189,15 +168,14 @@ object Context {
       params: List[String],
       args: Option[Seq[VAny]],
       popArgs: Boolean
-  ) = {
+  ) =
     val newInputs = args
       .map(_.toList)
-      .getOrElse(if (popArgs) currCtx.pop(arity) else currCtx.peek(arity))
-    if (currCtx.settings.logLevel == LogLevel.Debug) {
+      .getOrElse(if popArgs then currCtx.pop(arity) else currCtx.peek(arity))
+    if currCtx.settings.logLevel == LogLevel.Debug then
       println(
         s"newInputs = $newInputs, arity = $arity, stack = ${currCtx.stack}, popArgs = $popArgs"
       )
-    }
     new Context(
       mut.ArrayBuffer.empty,
       currCtx._contextVarN,
@@ -207,5 +185,5 @@ object Context {
       Some(currCtx),
       currCtx.globals
     )
-  }
-}
+  end makeFnCtx
+end Context

--- a/shared/src/main/scala/Elements.scala
+++ b/shared/src/main/scala/Elements.scala
@@ -3,14 +3,12 @@ package vyxal.impls
 // it's in a different package so that ElementTests can access the impls without
 // other classes being able to access them
 
-import scala.language.implicitConversions
-
 import vyxal.*
-import VNum.given
 
 import scala.io.StdIn
-
+import scala.language.implicitConversions
 import spire.algebra.*
+import VNum.given
 
 /** Implementations for elements */
 case class Element(
@@ -26,10 +24,10 @@ case class Element(
 case class UnimplementedOverloadException(element: String, args: Any)
     extends RuntimeException(s"$element not supported for inputs $args")
 
-object Elements {
+object Elements:
   val elements: Map[String, Element] = Impls.elements.toMap
 
-  private[impls] object Impls {
+  private[impls] object Impls:
     val elements = collection.mutable.Map.empty[String, Element]
 
     def addNilad(
@@ -37,7 +35,7 @@ object Elements {
         name: String,
         keywords: Seq[String],
         desc: String
-    )(impl: Context ?=> VAny): Unit = {
+    )(impl: Context ?=> VAny): Unit =
       elements += symbol -> Element(
         symbol,
         name,
@@ -47,7 +45,6 @@ object Elements {
         List(s"-> $desc"),
         () => ctx ?=> ctx.push(impl(using ctx))
       )
-    }
 
     def addMonadHelper(
         symbol: String,
@@ -56,7 +53,7 @@ object Elements {
         vectorises: Boolean,
         overloads: Seq[String],
         impl: Monad
-    ): Monad = {
+    ): Monad =
       elements += symbol -> Element(
         symbol,
         name,
@@ -69,7 +66,7 @@ object Elements {
         }
       )
       impl
-    }
+    end addMonadHelper
 
     /** Add a monad that handles all `VAny`s (it doesn't take a
       * `PartialFunction`, hence "Full")
@@ -132,7 +129,7 @@ object Elements {
         vectorises: Boolean,
         overloads: Seq[String],
         impl: Dyad
-    ): Dyad = {
+    ): Dyad =
       elements += symbol -> Element(
         symbol,
         name,
@@ -146,7 +143,7 @@ object Elements {
         }
       )
       impl
-    }
+    end addDyadHelper
 
     /** Add a dyad that handles all `VAny`s */
     def addDyadFull(
@@ -208,7 +205,7 @@ object Elements {
         vectorises: Boolean,
         overloads: Seq[String],
         impl: VyFn[3]
-    ): Triad = {
+    ): Triad =
       elements += symbol -> Element(
         symbol,
         name,
@@ -222,7 +219,7 @@ object Elements {
         }
       )
       impl
-    }
+    end addTriadHelper
 
     def addTriad(
         symbol: String,
@@ -261,7 +258,7 @@ object Elements {
         vectorises: Boolean,
         overloads: Seq[String],
         impl: VyFn[4]
-    ): Tetrad = {
+    ): Tetrad =
       elements += symbol -> Element(
         symbol,
         name,
@@ -275,7 +272,7 @@ object Elements {
         }
       )
       impl
-    }
+    end addTetradHelper
 
     def addTetrad(
         symbol: String,
@@ -329,18 +326,16 @@ object Elements {
       "a: list -> is (a) all truthy?"
     ) {
       case a: VNum =>
-        if (ListHelpers.makeIterable(a).forall(MiscHelpers.boolify(_))) { 1 }
-        else { 0 }
+        if ListHelpers.makeIterable(a).forall(MiscHelpers.boolify(_)) then 1
+        else 0
       case a: String => {
         var temp = VList()
-        for (i <- a) {
-          temp = VList(temp :+ StringHelpers.isVowel(i.toString)*)
-        }
+        for i <- a do temp = VList(temp :+ StringHelpers.isVowel(i.toString)*)
         temp
       }
       case a: VList =>
-        if (a.forall(MiscHelpers.boolify(_))) { 1 }
-        else { 0 }
+        if a.forall(MiscHelpers.boolify(_)) then 1
+        else 0
     }
 
     val concatenate = addDyad(
@@ -479,15 +474,11 @@ object Elements {
       List("get-input", "input", "stdin", "readline"),
       " -> input"
     ) { ctx ?=>
-      if (ctx.globals.inputs.nonEmpty) {
-        ctx.globals.inputs.next()
-      } else {
+      if ctx.globals.inputs.nonEmpty then ctx.globals.inputs.next()
+      else {
         val temp = StdIn.readLine()
-        if (temp.nonEmpty) {
-          Parser.parseInput(temp)
-        } else {
-          ctx.settings.defaultValue
-        }
+        if temp.nonEmpty then Parser.parseInput(temp)
+        else ctx.settings.defaultValue
       }
     }
 
@@ -568,7 +559,7 @@ object Elements {
       "a: fun -> first non-negative integer where predicate a is true"
     ) {
       case a: VNum   => -a
-      case a: String => a.map(c => if (c.isUpper) c.toLower else c.toUpper)
+      case a: String => a.map(c => if c.isUpper then c.toLower else c.toUpper)
       case a: VFun   => MiscHelpers.firstNonNegative(a)
     }
 
@@ -581,7 +572,7 @@ object Elements {
         "a: num -> chr(a)"
       ) {
         case a: String =>
-          if (a.length == 1) a.codePointAt(0)
+          if a.length == 1 then a.codePointAt(0)
           else VList(a.map(_.toInt: VNum)*)
         case a: VNum => a.toInt.toChar.toString
       }
@@ -680,13 +671,12 @@ object Elements {
       "*a, f -> f vectorised over however many arguments in a. It is recommended to use the modifier instead"
     ) { ctx ?=>
       // For sake of simplicity, error if not a function
-      ctx.pop() match {
+      ctx.pop() match
         case f: VFun => FuncHelpers.vectorise(f)
         case _ =>
           throw IllegalArgumentException(
             "Vectorise: First argument should be a function"
           )
-      }
     }
 
     // Constants
@@ -722,6 +712,5 @@ object Elements {
       List("empty-list", "nil-list", "new-list"),
       "[]"
     ) { VList.empty }
-
-  }
-}
+  end Impls
+end Elements

--- a/shared/src/main/scala/FuncHelpers.scala
+++ b/shared/src/main/scala/FuncHelpers.scala
@@ -3,7 +3,7 @@ package vyxal
 import vyxal.impls.UnimplementedOverloadException
 
 /** Helpers for function-related stuff */
-object FuncHelpers {
+object FuncHelpers:
 
   /** Take a monad and return a proper (not Partial) function that errors if
     * it's not defined for the input
@@ -12,54 +12,45 @@ object FuncHelpers {
       name: String,
       fn: Context ?=> PartialFunction[VAny, VAny]
   ): VAny => Context ?=> VAny = args =>
-    if (fn.isDefinedAt(args)) fn(args)
+    if fn.isDefinedAt(args) then fn(args)
     else throw UnimplementedOverloadException(name, args)
 
   /** Take a dyad and return a proper (not Partial) function that errors if it's
     * not defined for the input
     */
-  def fillDyad(name: String, fn: PartialVyFn[2]): Dyad = { (a, b) =>
+  def fillDyad(name: String, fn: PartialVyFn[2]): Dyad = (a, b) =>
     val args = (a, b)
-    if (fn.isDefinedAt(args)) fn(args)
+    if fn.isDefinedAt(args) then fn(args)
     else throw UnimplementedOverloadException(name, args)
-  }
 
   /** Take a triad and return a proper (not Partial) function that errors if
     * it's not defined for the input
     */
-  def fillTriad(name: String, fn: PartialVyFn[3]): Triad = { (a, b, c) =>
+  def fillTriad(name: String, fn: PartialVyFn[3]): Triad = (a, b, c) =>
     val args = (a, b, c)
-    if (fn.isDefinedAt(args)) fn(args)
+    if fn.isDefinedAt(args) then fn(args)
     else throw UnimplementedOverloadException(name, args)
-  }
 
   /** Take a tetrad and return a proper (not Partial) function that errors if
     * it's not defined for the input
     */
-  def fillTetrad(name: String, fn: PartialVyFn[4]): Tetrad = { (a, b, c, d) =>
+  def fillTetrad(name: String, fn: PartialVyFn[4]): Tetrad = (a, b, c, d) =>
     val args = (a, b, c, d)
-    if (fn.isDefinedAt(args)) fn(args)
+    if fn.isDefinedAt(args) then fn(args)
     else throw UnimplementedOverloadException(name, args)
-  }
 
-  def vectorise(fn: VFun)(using ctx: Context): Unit = {
-    if (fn.arity == 1) {
-      ctx.push(vectorise1(fn))
-    } else if (fn.arity == 2) {
-      ctx.push(vectorise2(fn))
-    } else if (fn.arity == 3) {
-      ???
-    } else if (fn.arity == 4) {
-      ???
-    } else {
+  def vectorise(fn: VFun)(using ctx: Context): Unit =
+    if fn.arity == 1 then ctx.push(vectorise1(fn))
+    else if fn.arity == 2 then ctx.push(vectorise2(fn))
+    else if fn.arity == 3 then ???
+    else if fn.arity == 4 then ???
+    else
       throw UnsupportedOperationException(
         s"Vectorising functions of arity ${fn.arity} not possible"
       )
-    }
-  }
 
-  private def vectorise1(fn: VFun)(using ctx: Context): VAny = {
-    ctx.pop() match {
+  private def vectorise1(fn: VFun)(using ctx: Context): VAny =
+    ctx.pop() match
       case lst: VList =>
         lst.vmap { elem =>
           ctx.push(elem)
@@ -68,13 +59,11 @@ object FuncHelpers {
       case x =>
         ctx.push(x)
         Interpreter.executeFn(fn)
-    }
-  }
 
-  private def vectorise2(fn: VFun)(using ctx: Context): VAny = {
+  private def vectorise2(fn: VFun)(using ctx: Context): VAny =
     val b, a = ctx.pop()
 
-    (a, b) match {
+    (a, b) match
       case (a: VList, b: VList) =>
         a.zipWith(b) { (x, y) =>
           ctx.push(x)
@@ -97,15 +86,15 @@ object FuncHelpers {
         ctx.push(a)
         ctx.push(b)
         Interpreter.executeFn(fn)
-    }
-  }
+    end match
+  end vectorise2
 
-  private def vectorise3(fn: VFun)(using ctx: Context): VAny = {
+  private def vectorise3(fn: VFun)(using ctx: Context): VAny =
     val a = ctx.pop()
     val b = ctx.pop()
     val c = ctx.pop()
 
-    (a, b, c) match {
+    (a, b, c) match
       case (a: VList, b: VList, c: VList) =>
         VList.zipMulti(a, b, c) { case Seq(x, y, z) =>
           ctx.push(x)
@@ -160,11 +149,10 @@ object FuncHelpers {
         ctx.push(b)
         ctx.push(c)
         Interpreter.executeFn(fn)
-    }
-  }
+    end match
+  end vectorise3
 
-  def reduceByElement(fn: VFun)(using ctx: Context): Unit = {
+  def reduceByElement(fn: VFun)(using ctx: Context): Unit =
     val iter = ctx.pop()
     ctx.push(MiscHelpers.reduce(iter, fn))
-  }
-}
+end FuncHelpers

--- a/shared/src/main/scala/Functions.scala
+++ b/shared/src/main/scala/Functions.scala
@@ -11,12 +11,11 @@ type Tetrad = (VAny, VAny, VAny, VAny) => Context ?=> VAny
 /** Make a function taking `Arity` VAnys TODO: Either merge this with Monad,
   * Dyad, etc. or make this accept tuples like it used to
   */
-type VyFn[Arity <: Int] = Arity match {
+type VyFn[Arity <: Int] = Arity match
   case 1 => Monad
   case 2 => Dyad
   case 3 => Triad
   case 4 => Tetrad
-}
 // type VyFn[Arity <: Int] = TupleOfSize[Arity] => Context ?=> VAny
 
 /** Same as [[VyFn]] but may be undefined for some inputs */
@@ -24,10 +23,9 @@ type PartialVyFn[Arity <: Int] =
   Context ?=> PartialFunction[TupleOfSize[Arity], VAny]
 
 /** Make a tuple of size `N` filled with [[VAny]]s */
-private type TupleOfSize[N <: Int] <: Tuple = N match {
+private type TupleOfSize[N <: Int] <: Tuple = N match
   case 0                        => EmptyTuple
   case compiletime.ops.int.S[n] => VAny *: TupleOfSize[n]
-}
 
 /** A function that operates directly on the stack */
 type DirectFn = () => Context ?=> Unit
@@ -36,13 +34,12 @@ extension (f: Monad)
   /** Turn the monad into a normal function of type `VAny => VAny` */
   def norm(using ctx: Context): VAny => VAny = f(_)(using ctx)
 
-  def vectorised = {
+  def vectorised =
     lazy val res: Monad = {
       case lhs: VAtom => f(lhs)
       case lst: VList => lst.vmap(res)
     }
     res
-  }
 
 extension (f: Dyad)
   /** Turn the dyad into a normal function of type `(VAny, VAny) => VAny` */
@@ -108,7 +105,7 @@ def forkify(impl: PartialVyFn[2]): PartialVyFn[2] = {
 // TODO reduce duplication between these functions and the ones in FuncHelpers.scala
 
 /** Vectorise an unvectorised monad */
-def vect1(name: String)(f: Context ?=> PartialFunction[VAny, VAny]): Monad = {
+def vect1(name: String)(f: Context ?=> PartialFunction[VAny, VAny]): Monad =
   val filled = FuncHelpers.fillMonad(name, f)
   lazy val res: Monad = {
     case lhs: VAtom => filled(lhs)
@@ -116,10 +113,9 @@ def vect1(name: String)(f: Context ?=> PartialFunction[VAny, VAny]): Monad = {
   }
 
   res
-}
 
 /** Vectorise an unvectorised dyad */
-def vect2(name: String)(f: PartialVyFn[2]): Dyad = {
+def vect2(name: String)(f: PartialVyFn[2]): Dyad =
   val filled = FuncHelpers.fillDyad(name, f)
   lazy val res: Dyad = {
     case (lhs: VAtom, rhs: VAtom) => filled(lhs, rhs)
@@ -129,10 +125,9 @@ def vect2(name: String)(f: PartialVyFn[2]): Dyad = {
   }
 
   res
-}
 
 /** Vectorise a triad */
-def vect3(name: String)(f: PartialVyFn[3]): VyFn[3] = {
+def vect3(name: String)(f: PartialVyFn[3]): VyFn[3] =
   val filled = FuncHelpers.fillTriad(name, f)
   lazy val res: VyFn[3] = {
     case (lhs: VAtom, rhs: VAtom, third: VAtom) => filled(lhs, rhs, third)
@@ -147,18 +142,17 @@ def vect3(name: String)(f: PartialVyFn[3]): VyFn[3] = {
       lhs.zipWith(third)(res(_, rhs, _))
     case (lhs: VList, rhs: VList, third: VList) =>
       VList.zipMulti(lhs, rhs, third) { zipped =>
-        (zipped: @unchecked) match {
+        (zipped: @unchecked) match
           case VList(l, r, t) =>
             f(
               l.asInstanceOf[VAtom],
               r.asInstanceOf[VAtom],
               t.asInstanceOf[VAtom]
             )
-        }
       }
   }
 
   res
-}
+end vect3
 
 // TODO: add vect4

--- a/shared/src/main/scala/Globals.scala
+++ b/shared/src/main/scala/Globals.scala
@@ -15,15 +15,14 @@ case class Globals(
     inputs: Inputs = Inputs(),
     settings: Settings = Settings(),
     var register: VAny = 0
-) {
+):
   register = settings.defaultValue
-}
 
 /** Stores the inputs for some Context. Inputs can be overridden.
   *
   * Implemented as a circular buffer to wrap around.
   */
-class Inputs(origInputs: Seq[VAny] = Seq.empty) {
+class Inputs(origInputs: Seq[VAny] = Seq.empty):
   private var origArr = origInputs.toArray
 
   /** Uses an array for constant access, not for mutating items */
@@ -35,23 +34,20 @@ class Inputs(origInputs: Seq[VAny] = Seq.empty) {
   def nonEmpty: Boolean = currInputs.nonEmpty
 
   /** Make sure to call [[this.nonEmpty]] first */
-  def next(): VAny = {
+  def next(): VAny =
     val res = currInputs(ind)
     ind = (ind + 1) % currInputs.size
     res
-  }
 
   /** Temporarily replace inputs with the given `Seq` */
-  def overrideInputs(newInputs: Seq[VAny]): Unit = {
+  def overrideInputs(newInputs: Seq[VAny]): Unit =
     currInputs = newInputs.toArray
     ind = 0
-  }
 
   /** Use the original inputs again */
-  def reset(): Unit = {
+  def reset(): Unit =
     currInputs = origArr
     ind = 0
-  }
 
   /** Get the current input without moving on to the one after that */
   def peek: VAny = currInputs(ind)
@@ -59,14 +55,13 @@ class Inputs(origInputs: Seq[VAny] = Seq.empty) {
   /** Get the next n inputs without moving the index/pointer forward (wrap if
     * necessary)
     */
-  def peek(n: Int): List[VAny] = {
+  def peek(n: Int): List[VAny] =
     // The number of elems that can be gotten without wrapping
     val numNonWrapping = n.max(currInputs.length - ind)
     val nonWrapping = currInputs.slice(ind, ind + numNonWrapping + 1).toList
 
-    if (n <= numNonWrapping) {
-      nonWrapping
-    } else {
+    if n <= numNonWrapping then nonWrapping
+    else {
       // The number of times the entire inputs array has to be repeated
       val numRepeats = (n - numNonWrapping) / currInputs.size
       val repeats = List.fill(numRepeats)(currInputs.toList)
@@ -77,12 +72,11 @@ class Inputs(origInputs: Seq[VAny] = Seq.empty) {
 
       nonWrapping ::: repeats.flatten ::: end
     }
-  }
-}
+  end peek
+end Inputs
 
-/** What kind of implicit output is wanted at the end
-  */
-enum EndPrintMode {
+/** What kind of implicit output is wanted at the end */
+enum EndPrintMode:
 
   /** Just print the top of the stack */
   case Default
@@ -93,12 +87,10 @@ enum EndPrintMode {
 
   /** Sum/concatenate the top of the stack */
   case Sum
-}
 
 // todo use a proper logging library instead
-enum LogLevel {
+enum LogLevel:
   case Debug, Normal
-}
 
 /** Settings set by flags
   *
@@ -121,14 +113,14 @@ case class Settings(
     numToRange: Boolean = false,
     printFn: Any => Unit = print,
     logLevel: LogLevel = LogLevel.Normal
-) {
+):
 
   /** Add a flag to these settings
     *
     * @return
     *   A Some with the new settings, or None if the flag is invalid
     */
-  def withFlag(flag: Char): Settings = flag match {
+  def withFlag(flag: Char): Settings = flag match
     case 'H' => this.copy(presetStack = true)
     case 'j' => this.copy(endPrintMode = EndPrintMode.JoinNewlines)
     case 'L' => this.copy(endPrintMode = EndPrintMode.JoinNewlinesVert)
@@ -138,5 +130,4 @@ case class Settings(
     case 'Ṁ' => this.copy(rangeStart = 0, rangeOffset = -1)
     // todo implement the others
     case _ => throw IllegalArgumentException(s"$flag is an invalid flag")
-  }
-}
+end Settings

--- a/shared/src/main/scala/Interpreter.scala
+++ b/shared/src/main/scala/Interpreter.scala
@@ -1,117 +1,100 @@
 package vyxal
 
 import vyxal.impls.Elements
+
 import VNum.given
 
-object Interpreter {
-  def execute(code: String)(using ctx: Context): Unit = {
-    Parser.parse(code) match {
+object Interpreter:
+  def execute(code: String)(using ctx: Context): Unit =
+    Parser.parse(code) match
       case Right(ast) =>
-        if (ctx.settings.logLevel == LogLevel.Debug) {
+        if ctx.settings.logLevel == LogLevel.Debug then
           println(s"Executing '$code' (ast: $ast)")
-        }
         execute(ast)
         // todo implicit output according to settings
-        if (
-          !ctx.isStackEmpty && ctx.settings.endPrintMode == EndPrintMode.Default
-        ) {
-          println(ctx.peek)
-        }
+        if !ctx.isStackEmpty && ctx.settings.endPrintMode == EndPrintMode.Default
+        then println(ctx.peek)
       case Left(error) =>
         println(s"Error while executing $code: $error")
         ???
-    }
-  }
 
-  def execute(ast: AST)(using ctx: Context): Unit = {
-    if (ctx.settings.logLevel == LogLevel.Debug) {
+  def execute(ast: AST)(using ctx: Context): Unit =
+    if ctx.settings.logLevel == LogLevel.Debug then
       println(s"Executing AST $ast, stack = ${ctx.peek(5)}")
-    }
-    ast match {
+    ast match
       case AST.Number(value) => ctx.push(value)
       case AST.Str(value)    => ctx.push(value)
       case AST.Lst(elems) =>
         val list = collection.mutable.ListBuffer.empty[VAny]
-        for (elem <- elems) {
+        for elem <- elems do
           given elemCtx: Context = ctx.makeChild()
           execute(elem)
           list += ctx.pop()
-        }
         ctx.push(VList(list.toList*))
       case AST.Command(cmd) =>
-        Elements.elements.get(cmd) match {
+        Elements.elements.get(cmd) match
           case Some(elem) => elem.impl()
           case None       => throw RuntimeException(s"No such command: '$cmd'")
-        }
       case AST.Group(elems, _) =>
         elems.foreach(Interpreter.execute(_))
       case AST.CompositeNilad(elems) =>
         elems.foreach(Interpreter.execute(_))
       case AST.If(thenBody, elseBody) =>
-        if (MiscHelpers.boolify(ctx.pop())) {
-          execute(thenBody)
-        } else if (elseBody.nonEmpty) {
-          execute(elseBody.get)
-        }
+        if MiscHelpers.boolify(ctx.pop()) then execute(thenBody)
+        else if elseBody.nonEmpty then execute(elseBody.get)
       case AST.While(None, body) =>
         val loopCtx = ctx.makeChild()
         loopCtx.contextVarN = ctx.settings.rangeStart
         loopCtx.contextVarM = 1
-        while (true) {
+        while true do
           execute(body)(using loopCtx)
           loopCtx.contextVarN = loopCtx.contextVarN.asInstanceOf[VNum] + 1
-        }
       case AST.While(Some(cond), body) =>
         execute(cond)
         given loopCtx: Context = ctx.makeChild()
         loopCtx.contextVarN = ctx.settings.rangeStart
         loopCtx.contextVarM = ctx.peek
-        while (MiscHelpers.boolify(ctx.pop())) {
+        while MiscHelpers.boolify(ctx.pop()) do
           execute(body)
           execute(cond)
           loopCtx.contextVarN = loopCtx.contextVarN.asInstanceOf[VNum] + 1
-        }
 
       case AST.For(None, body) =>
         val iterable =
           ListHelpers.makeIterable(ctx.pop(), Some(true))(using ctx)
         var index = 0
         given loopCtx: Context = ctx.makeChild()
-        for (elem <- iterable) {
+        for elem <- iterable do
           loopCtx.contextVarN = elem
           loopCtx.contextVarM = index
           index += 1
           execute(body)(using loopCtx)
-        }
 
       case AST.For(Some(name), body) =>
         val iterable =
           ListHelpers.makeIterable(ctx.pop(), Some(true))(using ctx)
         var index = 0
         given loopCtx: Context = ctx.makeChild()
-        for (elem <- iterable) {
+        for elem <- iterable do
           loopCtx.setVar(name, elem)
           loopCtx.contextVarN = elem
           loopCtx.contextVarM = index
           index += 1
           execute(body)(using loopCtx)
-        }
 
       case lam: AST.Lambda      => ctx.push(VFun.fromLambda(lam))
       case AST.FnDef(name, lam) => ctx.setVar(name, VFun.fromLambda(lam))
       case AST.GetVar(name)     => ctx.push(ctx.getVar(name))
       case AST.SetVar(name)     => ctx.setVar(name, ctx.pop())
       case AST.ExecuteFn =>
-        ctx.pop() match {
+        ctx.pop() match
           case fn: VFun => ctx.push(executeFn(fn))
           case _        => ???
-        }
       case _ => throw NotImplementedError(s"$ast not implemented")
-    }
-    if (ctx.settings.logLevel == LogLevel.Debug) {
+    end match
+    if ctx.settings.logLevel == LogLevel.Debug then
       println(s"res was ${ctx.peek}")
-    }
-  }
+  end execute
 
   /** Execute a function and return what was on the top of the stack, if there
     * was anything
@@ -127,7 +110,7 @@ object Interpreter {
       contextVarN: Option[VAny] = None,
       args: Option[Seq[VAny]] = None,
       popArgs: Boolean = true
-  )(using ctx: Context): VAny = {
+  )(using ctx: Context): VAny =
     val VFun(impl, arity, params, origCtx) = fn
     // println(s"Executing function with arity $arity")
     given fnCtx: Context =
@@ -139,5 +122,5 @@ object Interpreter {
     impl()(using fnCtx)
 
     fnCtx.pop()
-  }
-}
+  end executeFn
+end Interpreter

--- a/shared/src/main/scala/Lexer.scala
+++ b/shared/src/main/scala/Lexer.scala
@@ -1,11 +1,12 @@
 package vyxal
 
-import scala.util.parsing.combinator._
+import scala.util.parsing.combinator.*
+import VyxalToken.*
 
 case class VyxalCompilationError(msg: String)
 
 // todo maybe make a separate TokenType enum and make VyxalToken a simple case class
-enum VyxalToken(val value: String) {
+enum VyxalToken(val value: String):
   case Number(override val value: String) extends VyxalToken(value)
   case Str(override val value: String) extends VyxalToken(value)
   case StructureOpen(structureType: StructureType)
@@ -29,9 +30,9 @@ enum VyxalToken(val value: String) {
   case SetVar(override val value: String) extends VyxalToken(value)
   case Branch extends VyxalToken("|")
   case Newline extends VyxalToken("\n")
-}
+end VyxalToken
 
-enum StructureType(val open: String) {
+enum StructureType(val open: String):
   case If extends StructureType("[")
   case While extends StructureType("{")
   case For extends StructureType("(")
@@ -40,9 +41,6 @@ enum StructureType(val open: String) {
   case LambdaFilter extends StructureType("Ω")
   case LambdaReduce extends StructureType("₳")
   case LambdaSort extends StructureType("µ")
-}
-
-import VyxalToken.*
 
 val CODEPAGE = """ᵃᵇᶜᵈᵉᶠᶢᴴᶤᶨᵏᶪᵐⁿᵒᵖᴿᶳᵗᵘᵛᵂᵡᵞᶻᶴ′″‴⁴ᵜ !"#$%&'()*+,-./0123456789:;
 <=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~¦ȦḂĊḊĖḞĠḢİĿṀṄ
@@ -55,7 +53,7 @@ val TRIADIC_MODIFIERS = "‴"
 val TETRADIC_MODIFIERS = "⁴"
 val SPECIAL_MODIFIERS = "ᵗᵜ"
 
-object Lexer extends RegexParsers {
+object Lexer extends RegexParsers:
   override def skipWhitespace = true
 
   def number: Parser[VyxalToken] = """(0(?=[^.ı])|\d+(\.\d*)?(\ı\d*)?)""".r ^^ {
@@ -71,13 +69,12 @@ object Lexer extends RegexParsers {
     // So replace the non-normal string tokens with the appropriate token type
 
     val text = value.substring(1, value.length - 1)
-    value.charAt(value.length - 1) match {
+    value.charAt(value.length - 1) match
       case '"' => Str(text)
       case '„' => CompressedString(text)
       case '”' => DictionaryString(text)
       case '“' => CompressedNumber(text)
       case _   => throw Exception("Invalid string")
-    }
   }
 
   def singleCharString: Parser[VyxalToken] = """'.""".r ^^ { value =>
@@ -144,10 +141,8 @@ object Lexer extends RegexParsers {
     )
   )
 
-  def apply(code: String): Either[VyxalCompilationError, List[VyxalToken]] = {
-    (parse(tokens, code): @unchecked) match {
+  def apply(code: String): Either[VyxalCompilationError, List[VyxalToken]] =
+    (parse(tokens, code): @unchecked) match
       case NoSuccess(msg, next)  => Left(VyxalCompilationError(msg))
       case Success(result, next) => Right(result)
-    }
-  }
-}
+end Lexer

--- a/shared/src/main/scala/ListHelpers.scala
+++ b/shared/src/main/scala/ListHelpers.scala
@@ -1,10 +1,9 @@
 package vyxal
 
 import collection.mutable.ArrayBuffer
-
 import VNum.given
 
-object ListHelpers {
+object ListHelpers:
 
   /** Make an iterable from a value
     *
@@ -19,12 +18,12 @@ object ListHelpers {
       value: VAny,
       overrideRangify: Option[Boolean] = None
   )(using ctx: Context): VList =
-    value match {
+    value match
       case list: VList => list
       case str: String => VList(str.map(_.toString)*)
       case fn: VFun    => VList(fn)
       case num: VNum =>
-        if (overrideRangify.getOrElse(ctx.settings.rangify)) {
+        if overrideRangify.getOrElse(ctx.settings.rangify) then
           val start = ctx.settings.rangeStart
           val offset = ctx.settings.rangeOffset
           VList(
@@ -32,16 +31,12 @@ object ListHelpers {
               .to(num.toInt - offset.toInt)
               .map(VNum(_))*
           )
-        } else {
-          VList(num.toString.map(x => VNum.from(x.toString))*)
-        }
-    }
+        else VList(num.toString.map(x => VNum.from(x.toString))*)
 
-  def map(f: VFun, to: VList)(using ctx: Context): VList = {
+  def map(f: VFun, to: VList)(using ctx: Context): VList =
     VList(to.zipWithIndex.map { (item, index) =>
       f.execute(index, item, List(item))
     }*)
-  }
 
   /** Mold a list into a shape.
     * @param content
@@ -51,29 +46,26 @@ object ListHelpers {
     * @return
     *   VyList The content, molded into the shape.
     */
-  def mold(content: VList, shape: VList)(using ctx: Context): VList = {
-    def moldHelper(content: VList, shape: VList, ind: Int): VList = {
+  def mold(content: VList, shape: VList)(using ctx: Context): VList =
+    def moldHelper(content: VList, shape: VList, ind: Int): VList =
       val output = ArrayBuffer.empty[VAny]
       val mutContent = content
       val mutShape = shape.toList
       var index = ind
-      for item <- mutShape do {
-        item match {
+      for item <- mutShape do
+        item match
           case item: VList =>
             output += moldHelper(mutContent, item, index)
-            output.last match {
+            output.last match
               case list: VList => index += list.length - 1
               case _           => index += 1
-            }
           case item: VAny => output += mutContent(index)
-        }
         index += 1
-      }
 
       VList(output.toSeq*)
-    }
+    end moldHelper
     moldHelper(content, shape, 0)
-  }
+  end mold
 
   /** Split a list on a sublist
     *
@@ -85,20 +77,19 @@ object ListHelpers {
     *   sequence will be an empty list. If `sep` occurs at the very end of the
     *   list, the last element of the returned sequence will be an empty list.
     */
-  def split[T](list: Seq[T], sep: Seq[T]): Seq[Seq[T]] = {
+  def split[T](list: Seq[T], sep: Seq[T]): Seq[Seq[T]] =
     val parts = ArrayBuffer.empty[Seq[T]]
 
     var lastInd = 0
     var sliceInd = list.indexOfSlice(sep)
 
-    while (sliceInd != -1) {
+    while sliceInd != -1 do
       parts += list.slice(lastInd, sliceInd)
       lastInd = sliceInd + sep.length
       sliceInd = list.indexOfSlice(sep, lastInd)
-    }
 
     parts += list.slice(lastInd, list.length)
 
     parts.toSeq
-  }
-}
+  end split
+end ListHelpers

--- a/shared/src/main/scala/MiscHelpers.scala
+++ b/shared/src/main/scala/MiscHelpers.scala
@@ -5,7 +5,7 @@ import vyxal.VNum.given
 
 import spire.algebra.*
 
-object MiscHelpers {
+object MiscHelpers:
   // todo consider doing something like APL's forks so this doesn't have to be a partial function
   val add = vect2("add")(forkify {
     case (a: VNum, b: VNum)     => a + b
@@ -14,30 +14,26 @@ object MiscHelpers {
     case (a: String, b: String) => s"$a$b"
   })
 
-  def boolify(x: VAny) = x match {
+  def boolify(x: VAny) = x match
     case n: VNum   => n != VNum(0)
     case s: String => s.nonEmpty
     case f: VFun   => true
     case l: VList  => l.nonEmpty
-  }
 
-  def compare(a: VVal, b: VVal): Int = (a, b) match {
+  def compare(a: VVal, b: VVal): Int = (a, b) match
     case (a: VNum, b: VNum)     => a.real.compare(b.real)
     case (a: String, b: VNum)   => a.compareTo(b.toString)
     case (a: VNum, b: String)   => a.toString.compareTo(b)
     case (a: String, b: String) => a.compareTo(b)
-  }
 
-  def firstNonNegative(f: VFun)(using ctx: Context): Int = {
+  def firstNonNegative(f: VFun)(using ctx: Context): Int =
     var i = 0
-    while (true) {
+    while true do
       ctx.push(i)
       val result = executeFn(f)
-      if (boolify(result)) return i
+      if boolify(result) then return i
       i += 1
-    }
     ???
-  }
 
   val multiply = vect2("multiply") {
     case (a: VNum, b: VNum)     => a * b
@@ -49,43 +45,39 @@ object MiscHelpers {
 
   def reduce(iter: VAny, by: VFun, init: Option[VAny] = None)(using
       ctx: Context
-  ): VAny = {
+  ): VAny =
     var remaining = ListHelpers.makeIterable(iter, Some(true))(using ctx).toList
 
     // Convert niladic + monadic functions to be dyadic for reduction purposes
-    val byFun = by.withArity(if (by.arity < 2) 2 else by.arity)
+    val byFun = by.withArity(if by.arity < 2 then 2 else by.arity)
 
     // Take the first byFun.arity items as the initial set to operate on
-    var operating = init match {
+    var operating = init match
       case Some(elem) => elem +: remaining.take(byFun.arity - 1)
       case None       => remaining.take(byFun.arity)
-    }
     remaining = remaining.drop(operating.length)
 
-    if (operating.length == 0) { return 0 }
-    if (operating.length == 1) { return operating.head }
+    if operating.length == 0 then return 0
+    if operating.length == 1 then return operating.head
 
     var contextVarN = operating(0)
     var contextVarM = operating(1)
 
-    while remaining.length + operating.length != 1 do {
+    while remaining.length + operating.length != 1 do
       val result = byFun.execute(contextVarM, contextVarN, operating.reverse)
       contextVarM = remaining.headOption.getOrElse(result)
       contextVarN = result
       operating = result +: remaining.take(byFun.arity - 1)
       remaining = remaining.drop(byFun.arity - 1)
-    }
 
     contextVarN
-  }
+  end reduce
 
-  def vyPrint(x: VAny)(using ctx: Context): Unit = {
+  def vyPrint(x: VAny)(using ctx: Context): Unit =
     // todo change later
     ctx.settings.printFn(x)
-  }
 
-  def vyPrintln(x: VAny)(using Context): Unit = {
+  def vyPrintln(x: VAny)(using Context): Unit =
     vyPrint(x)
     vyPrint("\n")
-  }
-}
+end MiscHelpers

--- a/shared/src/main/scala/Modifiers.scala
+++ b/shared/src/main/scala/Modifiers.scala
@@ -22,7 +22,7 @@ case class Modifier(
 )(val from: PartialFunction[List[AST], AST])
 
 /** Implementations of modifiers */
-object Modifiers {
+object Modifiers:
   val modifiers: Map[String, Modifier] = Map(
     "v" -> Modifier(
       "Vectorise",
@@ -48,4 +48,4 @@ object Modifiers {
       AST.makeSingle(lambdaAst, AST.Command("R"))
     }
   )
-}
+end Modifiers

--- a/shared/src/main/scala/NumberHelpers.scala
+++ b/shared/src/main/scala/NumberHelpers.scala
@@ -5,54 +5,46 @@ import vyxal.VNum.given
 
 import scala.collection.mutable.ListBuffer
 
-object NumberHelpers {
+object NumberHelpers:
 
-  def fromBinary(a: VAny)(using ctx: Context): VAny = {
-    a match {
+  def fromBinary(a: VAny)(using ctx: Context): VAny =
+    a match
       case n: VNum   => fromBinary(n.toString())
       case l: VList  => toInt(l, 2)
       case s: String => toInt(s, 2)
       case _         => throw new Exception("Cannot convert to binary")
-    }
-  }
 
-  def multiplicity(a: VNum, b: VNum): VNum = {
+  def multiplicity(a: VNum, b: VNum): VNum =
     var result = 0
     var current = a.toInt
-    while (current % b.toInt == 0) {
+    while current % b.toInt == 0 do
       result += 1
       current /= b.toInt
-    }
     result
-  }
 
-  def range(a: VNum, b: VNum): VList = {
+  def range(a: VNum, b: VNum): VList =
     val start = a.toInt
     val end = b.toInt
-    val step = if (start < end) 1 else -1
+    val step = if start < end then 1 else -1
 
     VList((start to end by step).map(VNum(_))*)
-  }
 
-  def toBinary(a: VAny): VAny = {
-    a match {
+  def toBinary(a: VAny): VAny =
+    a match
       case n: VNum =>
         val binary = n.toInt.toBinaryString
         VList(binary.map(_.asDigit: VNum)*)
       case s: String =>
         // get binary representation of each character
         var result = ListBuffer.empty[VAny]
-        for (c <- s) {
+        for c <- s do
           val binary = c.toInt.toBinaryString
           result += VList(binary.map(_.asDigit).map(VNum(_)).toList*)
-        }
         VList(result.toList*)
       case _ => throw new Exception("Cannot convert to binary")
-    }
-  }
 
-  def toInt(value: VAny, radix: Int)(using ctx: Context): VAny = {
-    value match {
+  def toInt(value: VAny, radix: Int)(using ctx: Context): VAny =
+    value match
       case n: VNum => toInt(n.toString(), radix)
       case l: VList =>
         l.foldLeft(0: VAny) { (res, i) =>
@@ -61,6 +53,4 @@ object NumberHelpers {
 
       case s: String => BigInt(s.toUpperCase(), radix)
       case _         => throw new Exception("Cannot convert to int")
-    }
-  }
-}
+end NumberHelpers

--- a/shared/src/main/scala/Parser.scala
+++ b/shared/src/main/scala/Parser.scala
@@ -1,13 +1,13 @@
 package vyxal
 
-import scala.collection.mutable.Queue
-import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.Stack
-
 import vyxal.impls.Elements
+
+import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.Queue
+import scala.collection.mutable.Stack
 import spire.syntax.truncatedDivision
 
-object Parser {
+object Parser:
 
   /** The return type of a parser. If the parser fails, then it's a `Left`
     * containing a `VyxalCompilationError`. If the parser succeeds, it's a tuple
@@ -33,7 +33,7 @@ object Parser {
   private def parse(
       program: Queue[VyxalToken],
       topLevel: Boolean = false
-  ): ParserRet[AST] = {
+  ): ParserRet[AST] =
     val asts = Stack[AST]()
     // Convert the list of tokens to a queue so that ASTs like Structures can
     // freely take as many tokens as they need without needing to worry about
@@ -41,23 +41,19 @@ object Parser {
 
     // Begin the first sweep of parsing
 
-    while (program.nonEmpty && !isCloser(program.front)) {
-      (program.dequeue(): @unchecked) match {
+    while program.nonEmpty && !isCloser(program.front) do
+      (program.dequeue(): @unchecked) match
         // Numbers, strings and newlines are trivial, and are simply evaluated
         case VyxalToken.Number(value) =>
           asts.push(AST.Number(VNum.from(value)))
         case VyxalToken.Str(value) => asts.push(AST.Str(value))
         case VyxalToken.Newline    => asts.push(AST.Newline)
         case VyxalToken.StructureOpen(open) =>
-          parseStructure(open, program) match {
+          parseStructure(open, program) match
             case Right(ast) => asts.push(ast)
             case l          => return l
-          }
-          if (
-            topLevel && program.nonEmpty && program.front == VyxalToken.StructureAllClose
-          ) {
-            program.dequeue()
-          }
+          if topLevel && program.nonEmpty && program.front == VyxalToken.StructureAllClose
+          then program.dequeue()
         /*
          * List are just structures with two different opening and closing
          * token possibilities, so handle them the same way.
@@ -66,16 +62,14 @@ object Parser {
           var listDepth: Int = 1
           val elements = ListBuffer[List[VyxalToken]]()
           var element = List[VyxalToken]()
-          while (program.nonEmpty && listDepth > 0) {
+          while program.nonEmpty && listDepth > 0 do
             val listToken = program.dequeue()
-            listToken match {
+            listToken match
               case VyxalToken.Branch => {
-                if (listDepth == 1) {
+                if listDepth == 1 then
                   elements += element
                   element = List()
-                } else {
-                  element = element :+ listToken
-                }
+                else element = element :+ listToken
               }
               case VyxalToken.ListOpen => {
                 listDepth += 1
@@ -83,21 +77,18 @@ object Parser {
               }
               case VyxalToken.ListClose => {
                 listDepth -= 1
-                if (listDepth > 0)
-                  element = element :+ listToken
+                if listDepth > 0 then element = element :+ listToken
               }
               case _ => element = element :+ listToken
-            }
-          }
+            end match
+          end while
           elements += element
 
           val parsedElements = ListBuffer[AST]()
-          for (element <- elements) {
-            parse(element.to(Queue)) match {
+          for element <- elements do
+            parse(element.to(Queue)) match
               case Right(ast)  => parsedElements += ast
               case Left(error) => return Left(error)
-            }
-          }
           asts.push(AST.Lst(parsedElements.toList))
 
         /*
@@ -108,10 +99,9 @@ object Parser {
          * nilad. For arities -1 and 0, the command doesn't need to be grouped.
          */
         case VyxalToken.Command(name) =>
-          parseCommand(name, asts, program) match {
+          parseCommand(name, asts, program) match
             case Right(ast) => asts.push(ast)
             case l          => return l
-          }
         // At this stage, modifiers aren't explicitly handled, so just push a
         // temporary AST to comply with the type of the AST stack
         case VyxalToken.MonadicModifier(v) => asts.push(AST.JunkModifier(v, 1))
@@ -120,35 +110,30 @@ object Parser {
         case VyxalToken.TetradicModifier(v) =>
           asts.push(AST.JunkModifier(v, 4))
         case VyxalToken.SpecialModifier(v) => asts.push(AST.SpecialModifier(v))
-      }
-    }
+    end while
 
     val finalAsts = Stack[AST]()
-    while (!asts.isEmpty) {
+    while !asts.isEmpty do
       val topAst = asts.pop()
-      topAst match {
+      topAst match
         case AST.Newline => ???
         case AST.JunkModifier(name, arity) =>
-          if (arity > 0) {
+          if arity > 0 then
             val modifier = Modifiers.modifiers(name)
             val modifierArgs = List.fill(arity)(finalAsts.pop())
-            if (modifier.from.isDefinedAt(modifierArgs)) {
+            if modifier.from.isDefinedAt(modifierArgs) then
               finalAsts.push(modifier.from(modifierArgs))
-            } else {
+            else
               return Left(
                 VyxalCompilationError(
                   s"Modifier $name not defined for $modifierArgs"
                 )
               )
-            }
-          }
         case AST.SpecialModifier(name) => {
-          (name: @unchecked) match {
+          (name: @unchecked) match
             case "ᵜ" =>
               val lambdaAsts = ListBuffer[AST]()
-              while (asts.top != AST.Newline) {
-                lambdaAsts += finalAsts.pop()
-              }
+              while asts.top != AST.Newline do lambdaAsts += finalAsts.pop()
               finalAsts.push(
                 AST.Lambda(
                   1,
@@ -162,14 +147,13 @@ object Parser {
             // Why? Because the lexer only recognises ᵜ and ᵗ as special modifiers
             // if you've got to this case, then someone has figured out how to
             // screw around with ACE exploits. Good job, you.
-          }
         }
         case _ => finalAsts.push(topAst)
-      }
-    }
+      end match
+    end while
 
     Right(AST.makeSingle(finalAsts.toList*))
-  }
+  end parse
 
   /** This is the function that performs arity grouping of elements. Here's a
     * table of all the different groupings:
@@ -194,22 +178,18 @@ object Parser {
       name: String,
       asts: Stack[AST],
       program: Queue[VyxalToken]
-  ): ParserRet[AST] = {
-    Elements.elements.get(name) match {
+  ): ParserRet[AST] =
+    Elements.elements.get(name) match
       case None => Left(VyxalCompilationError(s"No such element: $name"))
       case Some(element) =>
-        if (asts.isEmpty) {
-          Right(AST.Command(name))
-        } else {
+        if asts.isEmpty then Right(AST.Command(name))
+        else {
           val arity = element.arity.getOrElse(0)
           val nilads = ListBuffer[AST]()
 
-          while (
-            asts.nonEmpty && nilads.size < arity
+          while asts.nonEmpty && nilads.size < arity
             && (asts.top.arity.fold(false)(_ == 0))
-          ) {
-            nilads += asts.pop()
-          }
+          do nilads += asts.pop()
           Right(
             AST.Group(
               (AST.Command(name) :: nilads.toList).reverse,
@@ -217,8 +197,6 @@ object Parser {
             )
           )
         }
-    }
-  }
 
   /** Parse branches for an unknown structure, nothing more.
     *
@@ -226,41 +204,33 @@ object Parser {
     *   The parsed branches, along with whether or not it encountered a
     *   `StructureAllClose`
     */
-  def parseBranches(program: Queue[VyxalToken]): ParserRet[List[AST]] = {
-    if (program.isEmpty) {
-      Right((List(AST.makeSingle()), None))
-    }
+  def parseBranches(program: Queue[VyxalToken]): ParserRet[List[AST]] =
+    if program.isEmpty then Right((List(AST.makeSingle()), None))
     val branches = ListBuffer.empty[AST]
 
-    while (
-      program.nonEmpty
+    while program.nonEmpty
       && (program.front == VyxalToken.Branch || !isCloser(program.front))
-    ) {
-      parse(program) match {
+    do
+      parse(program) match
         case Left(err) => return Left(err)
         case Right(ast) =>
           branches += ast
-          if (program.nonEmpty && program.front == VyxalToken.Branch) {
+          if program.nonEmpty && program.front == VyxalToken.Branch then
             // Get rid of the `|` token to move on to the next branch
             program.dequeue()
-            if (
-              program.isEmpty ||
+            if program.isEmpty ||
               (isCloser(program.front) && program.front != VyxalToken.Branch)
-            ) {
+            then
               // Don't forget empty branches at the end
               branches += AST.makeSingle()
-            }
-          }
-      }
-    }
+    end while
 
-    if (program.nonEmpty && program.front != VyxalToken.StructureAllClose) {
+    if program.nonEmpty && program.front != VyxalToken.StructureAllClose then
       // Get rid of the structure closer
       program.dequeue()
-    }
 
     Right(branches.toList)
-  }
+  end parseBranches
 
   /** @param structureType
     *   The opening character of the structure
@@ -283,49 +253,45 @@ object Parser {
   private def parseStructure(
       structureType: StructureType,
       program: Queue[VyxalToken]
-  ): ParserRet[AST] = {
+  ): ParserRet[AST] =
     val id =
       Option.when(structureType == StructureType.For)(parseIdentifier(program))
 
     parseBranches(program).flatMap { branches =>
       // Now, we can create the appropriate AST for the structure
-      structureType match {
+      structureType match
         case StructureType.If =>
-          branches match {
+          branches match
             case List(thenBranch) => Right(AST.If(thenBranch, None))
             case List(thenBranch, elseBranch) =>
               Right(AST.If(thenBranch, Some(elseBranch)))
             case _ =>
               Left(VyxalCompilationError("Invalid if statement"))
             // TODO: One day make this extended elif
-          }
         case StructureType.While =>
-          branches match {
+          branches match
             case List(cond, body) => Right(AST.While(Some(cond), body))
             case List(body)       => Right(AST.While(None, body))
             case _ =>
               Left(VyxalCompilationError("Invalid while statement"))
-          }
         case StructureType.For =>
-          branches match {
+          branches match
             case List(cond, body) =>
               val name = Some(toValidName(id.get))
               Right(AST.For(name, body))
             case List(body) => Right(AST.For(None, body))
             case _ =>
               Left(VyxalCompilationError("Invalid for statement"))
-          }
         case lambdaType @ (StructureType.Lambda | StructureType.LambdaMap |
             StructureType.LambdaFilter | StructureType.LambdaReduce |
             StructureType.LambdaSort) =>
-          val lambda = branches match {
+          val lambda = branches match
             // todo actually parse arity and parameters
             case List(body) => AST.Lambda(1, List.empty, body)
             case _          => ???
-          }
           // todo using the command names is a bit brittle
           //   maybe refer to the functions directly
-          Right(lambdaType match {
+          Right(lambdaType match
             case StructureType.Lambda => lambda
             case StructureType.LambdaMap =>
               AST.makeSingle(lambda, AST.Command("M"))
@@ -335,56 +301,48 @@ object Parser {
               AST.makeSingle(lambda, AST.Command("R"))
             case StructureType.LambdaSort =>
               AST.makeSingle(lambda, AST.Command("ṡ"))
-          })
-      }
+          )
     }
-  }
+  end parseStructure
 
   /** Parse an identifier (for for loops) */
-  private def parseIdentifier(program: Queue[VyxalToken]): String = {
+  private def parseIdentifier(program: Queue[VyxalToken]): String =
     val id = StringBuilder()
-    while (program.nonEmpty && !isCloser(program.front)) {
+    while program.nonEmpty && !isCloser(program.front) do
       id ++= program.front.value
-    }
-    if (program.nonEmpty && program.front == VyxalToken.Branch) {
+    if program.nonEmpty && program.front == VyxalToken.Branch then
       // Get rid of `|` so that the other branches can be parsed
       program.dequeue()
-    }
     toValidName(id.toString())
-  }
 
   /** Whether this token is a branch or a structure/list closer */
   def isCloser(token: VyxalToken): Boolean =
-    token match {
+    token match
       case VyxalToken.Branch            => true
       case VyxalToken.ListClose         => true
       case VyxalToken.StructureClose(_) => true
       case VyxalToken.StructureAllClose => true
       case _                            => false
-    }
 
-  def parse(code: String): Either[VyxalCompilationError, AST] = {
+  def parse(code: String): Either[VyxalCompilationError, AST] =
     Lexer(code).flatMap { tokens =>
       val preprocessed = preprocess(tokens).to(Queue)
       val parsed = parse(preprocessed, true)
-      if (preprocessed.nonEmpty) {
+      if preprocessed.nonEmpty then
         // Some tokens were left at the end, which should never happen
         Left(
           VyxalCompilationError(
             s"Error parsing code: These tokens were not parsed ${preprocessed.toList}"
           )
         )
-      } else {
-        parsed match {
+      else
+        parsed match
           case Right(ast) => Right(postprocess(ast))
           case Left(error) =>
             Left(VyxalCompilationError(s"Error parsing code: $error"))
-        }
-      }
     }
-  }
 
-  private def preprocess(tokens: List[VyxalToken]): List[VyxalToken] = {
+  private def preprocess(tokens: List[VyxalToken]): List[VyxalToken] =
     val processed = ListBuffer[VyxalToken]()
     tokens.foreach {
       case VyxalToken.StructureClose(")") =>
@@ -393,37 +351,31 @@ object Parser {
       case x => processed += x
     }
     processed.toList
-  }
 
-  private def postprocess(asts: AST): AST = {
-    val temp = asts match {
+  private def postprocess(asts: AST): AST =
+    val temp = asts match
       case AST.Group(elems, _) => {
         val nilads = elems.reverse.takeWhile(isNilad).reverse
         val rest = elems.dropRight(nilads.length)
         AST.Group(nilads ++ rest, None)
       }
       case _ => asts
-    }
     temp
-  }
 
   private def isNilad(ast: AST) = ast.arity == Some(0)
 
-  def parseInput(input: String): VAny = {
+  def parseInput(input: String): VAny =
     Lexer(input).toOption
       .flatMap { tokens =>
-        parse(tokens.to(Queue), true) match {
+        parse(tokens.to(Queue), true) match
           case Right(ast) =>
-            ast match {
+            ast match
               case AST.Number(n) => Some[VAny](n)
               case AST.Str(s)    => Some(s)
               case AST.Lst(l) =>
                 Some(VList(l.map(e => parseInput(e.toString))*))
               case _ => None
-            }
           case Left(_) => None
-        }
       }
       .getOrElse(input)
-  }
-}
+end Parser

--- a/shared/src/main/scala/StringHelpers.scala
+++ b/shared/src/main/scala/StringHelpers.scala
@@ -1,49 +1,43 @@
 package vyxal
 
-import VNum.given
-
 import collection.mutable.StringBuilder
 import scala.util.matching.Regex
-
 import spire.implicits.*
+import VNum.given
 
-object StringHelpers {
+object StringHelpers:
 
-  def countString(haystack: String, needle: String): Int = {
+  def countString(haystack: String, needle: String): Int =
     haystack.split(needle, -1).length - 1
-  }
 
-  def formatString(fmtstr: String, args: Any*): String = {
+  def formatString(fmtstr: String, args: Any*): String =
     val sb = StringBuilder()
     var i = 0
     var j = 0
-    while (i < fmtstr.length) {
-      if (fmtstr(i) == '%') {
-        if (i + 1 < fmtstr.length && fmtstr(i + 1) == '%') {
+    while i < fmtstr.length do
+      if fmtstr(i) == '%' then
+        if i + 1 < fmtstr.length && fmtstr(i + 1) == '%' then
           sb.append('%')
           i += 2
-        } else {
+        else {
           sb.append(args(j % args.length))
           i += 1
         }
-      } else {
+      else {
         sb.append(fmtstr(i))
         i += 1
       }
-    }
     sb.toString
-  }
+  end formatString
 
-  def isVowel(c: String): VNum = c.toLowerCase() match {
+  def isVowel(c: String): VNum = c.toLowerCase() match
     case "a" | "e" | "i" | "o" | "u" => 1
     case _                           => 0
-  }
 
   /** Remove the character at the given index */
-  def remove(s: String, i: Int): String = {
+  def remove(s: String, i: Int): String =
     val wrapped = (i + s.length) % s.length
     s.substring(0, wrapped) + s.substring(wrapped + 1)
-  }
 
   /** Ring translates a given string according to the provided mapping \- that
     * is, map matching elements to the subsequent element in the translation
@@ -52,7 +46,7 @@ object StringHelpers {
   def ringTranslate(source: String, mapping: String): String =
     source.map { c =>
       val index = mapping.indexOf(c)
-      if (index == -1) c
+      if index == -1 then c
       else mapping((index + 1) % mapping.length)
     }.mkString
-}
+end StringHelpers

--- a/shared/src/main/scala/VAny.scala
+++ b/shared/src/main/scala/VAny.scala
@@ -4,7 +4,6 @@ import vyxal.impls.Element
 import vyxal.Interpreter.executeFn
 
 import scala.reflect.TypeTest
-
 import spire.algebra.*
 import spire.implicits.*
 import spire.math.{Complex, Real}
@@ -30,7 +29,7 @@ case class VFun(
     arity: Int,
     params: List[String],
     ctx: Context
-) {
+):
 
   /** Make a copy of this function with a different arity. */
   def withArity(newArity: Int): VFun = this.copy(arity = newArity)
@@ -51,10 +50,10 @@ case class VFun(
 
   def apply(args: VAny*)(using ctx: Context): VAny =
     Interpreter.executeFn(this)
-}
+end VFun
 
-object VFun {
-  def fromLambda(lam: AST.Lambda)(using origCtx: Context): VFun = {
+object VFun:
+  def fromLambda(lam: AST.Lambda)(using origCtx: Context): VFun =
     val AST.Lambda(arity, params, body) = lam
     VFun(
       () => ctx ?=> Interpreter.execute(body)(using ctx),
@@ -62,19 +61,14 @@ object VFun {
       params,
       origCtx
     )
-  }
 
-  def fromElement(elem: Element)(using origCtx: Context): VFun = {
+  def fromElement(elem: Element)(using origCtx: Context): VFun =
     val Element(symbol, name, _, arity, _, _, impl) = elem
     VFun(impl, arity.getOrElse(1), List.empty, origCtx)
-  }
-}
 
 extension (self: VAny)
-  def ===(that: VAny): Boolean = {
-    (self, that) match {
-      case (a: VVal, b: VVal) => MiscHelpers.compare(a, b) == 0
+  def ===(that: VAny): Boolean =
+    (self, that) match
+      case (a: VVal, b: VVal)   => MiscHelpers.compare(a, b) == 0
       case (a: VList, b: VList) => a == b
       case _                    => false
-    }
-  }

--- a/shared/src/main/scala/VList.scala
+++ b/shared/src/main/scala/VList.scala
@@ -12,10 +12,9 @@ import scala.collection.SpecificIterableFactory
   */
 class VList private (val lst: Seq[VAny])
     extends Seq[VAny],
-      SeqOps[VAny, Seq, VList] {
+      SeqOps[VAny, Seq, VList]:
 
-  /** Map the list using a Vyxal function
-    */
+  /** Map the list using a Vyxal function */
   def vmap(f: VAny => Context ?=> VAny)(using Context): VList = new VList(
     lst.map(f(_))
   )
@@ -32,19 +31,14 @@ class VList private (val lst: Seq[VAny])
         .map(f(_, _))
     )
 
-  /** Get the element at index `ind`
-    */
+  /** Get the element at index `ind` */
   override def apply(ind: Int): VAny =
-    if (ind < 0) {
+    if ind < 0 then
       // floorMod because % gives negative results with negative dividends
       lst(Math.floorMod(ind, lst.length))
-    } else {
-      try {
-        lst(ind)
-      } catch {
-        case _: IndexOutOfBoundsException => lst(ind % lst.length)
-      }
-    }
+    else
+      try lst(ind)
+      catch case _: IndexOutOfBoundsException => lst(ind % lst.length)
 
   override def iterator: Iterator[VAny] = lst.iterator
 
@@ -61,18 +55,17 @@ class VList private (val lst: Seq[VAny])
     VList.newBuilder
 
   override def empty: VList = VList.empty
-}
+end VList
 
-object VList extends SpecificIterableFactory[VAny, VList] {
+object VList extends SpecificIterableFactory[VAny, VList]:
 
   /** Zip multiple VLists together with a function.
     *
     * The parameter is a `PartialFunction` instead of a function because it's
     * going to match on a list and assume it's a specific length
     */
-  def zipMulti(lists: VList*)(f: PartialFunction[Seq[VAny], VAny]): VList = {
+  def zipMulti(lists: VList*)(f: PartialFunction[Seq[VAny], VAny]): VList =
     ???
-  }
 
   /** This lets us pattern match on `VList`s, silly as the implementation may
     * be.
@@ -89,4 +82,4 @@ object VList extends SpecificIterableFactory[VAny, VList] {
   override def fromSpecific(it: IterableOnce[VAny]): VList = new VList(
     it.iterator.toSeq
   )
-}
+end VList

--- a/shared/src/main/scala/VNum.scala
+++ b/shared/src/main/scala/VNum.scala
@@ -1,10 +1,9 @@
 package vyxal
 
 import scala.language.implicitConversions
-
 import spire.math.{Complex, Real}
 
-class VNum private (val underlying: Complex[Real]) {
+class VNum private (val underlying: Complex[Real]):
   def real = underlying.real
   def imag = underlying.imag
 
@@ -22,16 +21,15 @@ class VNum private (val underlying: Complex[Real]) {
     Complex(this.real.tmod(rhs.real), this.imag.tmod(rhs.imag))
 
   override def toString =
-    if (this.imag == 0) this.real.toString else this.underlying.toString
+    if this.imag == 0 then this.real.toString else this.underlying.toString
 
-  override def equals(obj: Any) = obj match {
+  override def equals(obj: Any) = obj match
     case n: VNum => underlying == n.underlying
     case _       => false
-  }
-}
+end VNum
 
 /** Be sure to import `VNum.given` to be able to match on VNums and stuff */
-object VNum {
+object VNum:
 
   /** To force an implicit conversion */
   def apply(n: VNum): VNum = n
@@ -40,7 +38,7 @@ object VNum {
 
   // todo implement properly
   /** Parse a number from a string */
-  def from(s: String): VNum = {
+  def from(s: String): VNum =
     // Not as simple as it seems - can't just use Number.parse
     // because it doesn't handle hanging decimals (3. -> 3.5) nor
     // complex numbers (3ı4 -> 3+4i)
@@ -51,12 +49,12 @@ object VNum {
     val real = parts(0)
     val imag = parts.lift(1).getOrElse("0")
 
-    val realNum = (if (real.last == '.') real + "5" else real).toInt
-    val imagNum = (if (imag.last == '.') imag + "5" else imag).toInt
+    val realNum = (if real.last == '.' then real + "5" else real).toInt
+    val imagNum = (if imag.last == '.' then imag + "5" else imag).toInt
 
-    if (imagNum == 0) complex(realNum, 0)
+    if imagNum == 0 then complex(realNum, 0)
     else complex(realNum, imagNum)
-  }
+  end from
 
   /** Allow pattern matching like `VNum(r, i)` */
   def unapply(n: VNum): (Real, Real) = n.underlying.asTuple
@@ -70,4 +68,4 @@ object VNum {
   given Conversion[BigInt, VNum] = n => complex(n, 0)
   given Conversion[Complex[Real], VNum] = new VNum(_)
   given Conversion[Boolean, VNum] = b => if b then 1 else 0
-}
+end VNum

--- a/shared/src/test/scala/InterpreterTests.scala
+++ b/shared/src/test/scala/InterpreterTests.scala
@@ -2,7 +2,7 @@ package vyxal
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class InterpreterTests extends AnyFunSuite {
+class InterpreterTests extends AnyFunSuite:
   test("Can the interpreter make lists?") {
     given ctx: Context = Context()
     Interpreter.execute("#[1 | 2 3 + | 4#]")
@@ -82,4 +82,4 @@ class InterpreterTests extends AnyFunSuite {
     )
     assertResult(VList(-4, 1, VList(-4, -5)))(ctx.pop())
   }
-}
+end InterpreterTests


### PR DESCRIPTION
Add some Scalafmt rules to automatically rewrite to the new syntax and also group imports. Since it ended up making a *lot* of changes, I made a PR instead of committing directly. The PR should probably be directed towards a different branch but this is more convenient and less likely to cause problems later. One thing that needs some discussion is how many lines are needed before the `end` marker should be inserted. I went with 15 for now but we could make that smaller or bigger depending on what y'all want.