### PR TITLE
Deploy Scaladocs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: 'scaladoc'
 
       - name: Setup Pages
         uses: actions/configure-pages@v2

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -34,11 +34,14 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
 
-      - name: Create docs with SBT
-        id: sbt
-        uses: ankitguptag18/github-action-sbt@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-           command: doc
+          java-version: '17'
+          distribution: 'adopt'
+      
+      - name: Build docs
+        run: sbt doc
 
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -34,14 +34,11 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Create docs with SBT
+        id: sbt
+        uses: ankitguptag18/github-action-sbt@v1
         with:
-          java-version: '17'
-          distribution: 'adopt'
-      
-      - name: Build docs
-        run: sbt doc
+           command: doc
 
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -1,0 +1,51 @@
+name: Generate docs
+
+on:
+  push:
+    branches:
+      - scaladoc # todo change this to the "main" v3 branch
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      
+      - name: Build docs
+        run: sbt doc
+
+      - name: Upload built HTML
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -43,10 +43,13 @@ jobs:
       - name: Build docs
         run: sbt vyxalJVM/doc
 
+        # Move docs to pages directory
+      - run: mkdir pages && mv docs/ pages/
+
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1
         with:
-          path: './docs'
+          path: './pages'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'adopt'
       
       - name: Build docs
-        run: sbt doc
+        run: sbt vyxalJVM/doc
 
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,10 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
       vyxalVersion,
       "-groups", // Group similar functions
       "-Ygenerate-inkuire", // Allow type-based searches
-      "-external-mappings:.*scala.*::scaladoc3::https://scala-lang.org/api/3.x/,.*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/"
+      "-external-mappings:.*vyxal.*::scaladoc3::https://vyxal.github.io/Vyxal/docs/",
+      "-external-mappings:.*scala.util.parsing.*::scaladoc3::https://scala-lang.org/api/2.12.8/scala-parser-combinators/",
+      "-external-mappings:.*scala(?!.util.parsing).*::scaladoc3::https://scala-lang.org/api/3.x/",
+      "-external-mappings:.*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/"
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,8 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
     Compile / doc / scalacOptions ++= Seq(
       "-project-version",
       vyxalVersion,
-      "-groups",
+      "-groups", // Group similar functions
+      "-Ygenerate-inkuire" // Allow type-based searches
     )
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,13 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
       "-print-lines",
       "-Ycheck-all-patmat"
     ),
+    // Configure Scaladoc
+    Compile / doc / target := file("docs"),
+    Compile / doc / scalacOptions ++= Seq(
+      "-project-version",
+      vyxalVersion,
+      "-groups",
+    )
   )
   .jvmSettings(
     // JVM-specific settings

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
       "-project-version",
       vyxalVersion,
       "-groups", // Group similar functions
-      "-Ygenerate-inkuire" // Allow type-based searches
+      "-Ygenerate-inkuire", // Allow type-based searches
+      "-external-mappings:.*scala.*::scaladoc3::https://scala-lang.org/api/3.x/,.*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/"
     )
   )
   .jvmSettings(


### PR DESCRIPTION
This PR is for v3, not v2. It'll deploy Scaladocs to `vyxal.github.io/Vyxal/docs` (shouldn't mess with the interpreter because the interpreter will be at `vyxal.github.io/Vyxal`). It's not actually needed because Vyxal's an application, not a library, but it might help people new to v3. I'll admit that I'm mainly doing this because it'd be kinda cool.

<s>I think GitHub Pages needs to enabled first, though.</s> Thanks lyxal