### PR TITLE
Get rid of nonlocal returns warning

### DIFF
--- a/shared/src/main/scala/VNum.scala
+++ b/shared/src/main/scala/VNum.scala
@@ -32,7 +32,7 @@ end VNum
 object VNum:
 
   /** To force an implicit conversion */
-  def apply(n: VNum): VNum = n
+  def apply[T](n: T)(using Conversion[T, VNum]): VNum = n
 
   def complex(real: Real, imag: Real) = new VNum(Complex(real, imag))
 

--- a/shared/src/test/scala/ParserTests.scala
+++ b/shared/src/test/scala/ParserTests.scala
@@ -132,6 +132,7 @@ class ParserTests extends AnyFunSuite:
       Parser.parse("('|") === Right(For(None, Str("|")))
     )
   }
+
   test("Does the parser recognise two-character strings in structures?") {
     assert(
       Parser.parse("(bᶴ|c") === Right(
@@ -161,6 +162,14 @@ class ParserTests extends AnyFunSuite:
             )
           )
         )
+    )
+  }
+
+  test("Does the parser auto-close lists in structures?") {
+    assert(
+      Parser.parse("(2 #[} +") === Right(
+        Group(List(For(None, Group(List(Number(2), Lst(List())), None)), Command("+")), None)
+      )
     )
   }
 


### PR DESCRIPTION
Scala is going to stop supporting letting you return from a for loop because they're syntactic sugar for `.foreach`, so this PR changes the list parsing to use the `parseBranches` function that was already being used for structures.