### PR TITLE
Implement execute (`Ė`)

### DIFF
--- a/documentation/elements.txt
+++ b/documentation/elements.txt
@@ -42,6 +42,9 @@ B (Convert From Binary) (non-vectorising)
 - a: lst -> int(a, 2), using list of digits
 ---------------------
 Ė (Execute lambda | Evaluate as Vyxal | Power with base 10) (non-vectorising)
+- a: fun -> Execute a
+- a: str -> Evaluate a as Vyxal
+- a: num -> 10 ** n
 ---------------------
 + (Addition) (vectorising)
 - a: num, b: num -> a + b

--- a/shared/src/main/scala/Context.scala
+++ b/shared/src/main/scala/Context.scala
@@ -1,7 +1,7 @@
 package vyxal
 
-import scala.collection.{mutable as mut}
 import scala.collection.mutable.Stack
+import scala.collection.mutable as mut
 import scala.io.StdIn
 
 /** @constructor
@@ -36,11 +36,10 @@ class Context private (
     val elem =
       if stack.nonEmpty then stack.remove(stack.size - 1)
       else if inputs.nonEmpty then inputs.next()
-      else {
+      else
         val temp = StdIn.readLine()
         if temp.nonEmpty then Parser.parseInput(temp)
         else settings.defaultValue
-      }
     if settings.logLevel == LogLevel.Debug then println(s"Popped $elem")
     elem
 

--- a/shared/src/main/scala/Elements.scala
+++ b/shared/src/main/scala/Elements.scala
@@ -443,6 +443,19 @@ object Elements:
       "a ->"
     ) { ctx ?=> ctx.pop() }
 
+    val execute = addMonad(
+      "Ė",
+      "Execute lambda | Evaluate as Vyxal | Power with base 10",
+      List("execute-lambda", "evaluate-as-vyxal", "power-base-10"),
+      false
+    ) {
+      case fn: VFun => Interpreter.executeFn(fn)
+      case code: String =>
+        Interpreter.execute(code)
+        summon[Context].pop()
+      case n: VNum => 10 ** n
+    }
+
     val factorial = addMonadVect(
       "!",
       "Factorial | To Uppercase",
@@ -475,11 +488,10 @@ object Elements:
       " -> input"
     ) { ctx ?=>
       if ctx.globals.inputs.nonEmpty then ctx.globals.inputs.next()
-      else {
+      else
         val temp = StdIn.readLine()
         if temp.nonEmpty then Parser.parseInput(temp)
         else ctx.settings.defaultValue
-      }
     }
 
     val greaterThan = addDyadVect(

--- a/shared/src/main/scala/Elements.scala
+++ b/shared/src/main/scala/Elements.scala
@@ -447,7 +447,10 @@ object Elements:
       "Ė",
       "Execute lambda | Evaluate as Vyxal | Power with base 10",
       List("execute-lambda", "evaluate-as-vyxal", "power-base-10"),
-      false
+      false,
+      "a: fun -> Execute a",
+      "a: str -> Evaluate a as Vyxal",
+      "a: num -> 10 ** n"
     ) {
       case fn: VFun => Interpreter.executeFn(fn)
       case code: String =>

--- a/shared/src/main/scala/Lexer.scala
+++ b/shared/src/main/scala/Lexer.scala
@@ -144,7 +144,7 @@ object Lexer extends RegexParsers:
   def newlines = "\n" ^^^ Newline
 
   def tokens: Parser[List[VyxalToken]] = phrase(
-    rep1(
+    rep(
       comment | branch | number | string | getVariable | setVariable | twoCharString | singleCharString | digraph
         | monadicModifier | dyadicModifier | triadicModifier | tetradicModifier
         | specialModifier | structureOpen | structureClose | structureAllClose

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -1,12 +1,12 @@
 package vyxal.impls
 
-import org.scalatest.funspec.AnyFunSpec
-
 import vyxal.*
+
+import org.scalatest.funspec.AnyFunSpec
 import Elements.Impls
 
 /** Tests for specific elements */
-class ElementTests extends AnyFunSpec {
+class ElementTests extends AnyFunSpec:
 
   describe("Element +") {
     describe("when given lists") {
@@ -81,4 +81,38 @@ class ElementTests extends AnyFunSpec {
       }
     }
   }
-}
+
+  describe("Element Ė") {
+    describe("when given a number") {
+      it("should do 10**n properly") {
+        given ctx: Context = Context()
+        assertResult(1: VNum)(Impls.execute(0))
+        assertResult(100: VNum)(Impls.execute(2))
+        assertResult(VNum(1) / 1000)(Impls.execute(-3))
+      }
+    }
+
+    describe("when given a string") {
+      it("should properly execute code that uses the stack") {
+        given ctx: Context = Context()
+        assertResult(3: VNum)(Impls.execute("1 2 + D"))
+      }
+
+      it("should use the same context for executing the code") {
+        given ctx: Context = Context(inputs = List(3, 4))
+        assertResult(7: VNum)(Impls.execute("+"))
+      }
+    }
+
+    describe("when given a function") {
+      it("should execute the function") {
+        given ctx: Context = Context()
+        ctx.push(1)
+        ctx.push(2)
+        assertResult(3: VNum)(
+          Impls.execute(VFun.fromElement(Elements.elements("+")))
+        )
+      }
+    }
+  }
+end ElementTests

--- a/shared/src/test/scala/InterpreterTests.scala
+++ b/shared/src/test/scala/InterpreterTests.scala
@@ -35,6 +35,16 @@ class InterpreterTests extends AnyFunSuite:
     assert(ctx.pop() == VList(VList(4, 4), VList(VList(5, 0), VList(6, 0))))
   }
 
+  test("Can the interpreter execute named functions?") {
+    given ctx: Context = Context()
+    ctx.push(3)
+    ctx.push(4)
+    Interpreter.execute(AST.FnDef("f", AST.Lambda(2, List.empty, AST.Command("-"))))
+    Interpreter.execute(AST.GetVar("f"))
+    Interpreter.execute(AST.Command("Ė"))
+    assertResult(VNum(-1))(ctx.pop())
+  }
+
   test("Can the interpreter execute monadic lambdas?") {
     given ctx: Context = Context()
     Interpreter.execute(

--- a/shared/src/test/scala/ParserTests.scala
+++ b/shared/src/test/scala/ParserTests.scala
@@ -4,6 +4,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import AST.*
 
 class ParserTests extends AnyFunSuite:
+  test("Can the parser parse an empty string?") {
+    assert(Parser.parse("") === Right(AST.makeSingle()))
+  }
+
   test("Does the parser recognise numbers?") {
     assert(Parser.parse("123") === Right(Number(123)))
   }


### PR DESCRIPTION
Implement the `Ė` element (there wasn't really anything to "implement", just needed to add an element that called all the methods already implemented). Added a few tests for `Ė`.