### PR TITLE
Improve printing of complex numbers

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -6209,7 +6209,18 @@ def vy_print(lhs, end="\n", ctx=None):
             if ctx.print_decimals and not lhs.is_Integer:
                 lhs = str(float(lhs))
             else:
-                lhs = sympy.nsimplify(lhs.round(20), rational=True)
+                # Determine if the number is a imaginary sympy literal
+                if not lhs.is_real:
+                    if ctx.print_decimals:
+                        lhs = sympy.nsimplify(lhs)
+                    else:
+                        lhs = (
+                            str(lhs.as_real_imag()[0])
+                            + "°"
+                            + str(lhs.as_real_imag()[1])
+                        )
+                else:
+                    lhs = sympy.nsimplify(lhs.round(20), rational=True)
         if ctx.online:
             ctx.online_output[1] += vy_str(lhs, ctx=ctx) + end
         else:


### PR DESCRIPTION
Something like `5°2 2 e` would otherwise error