### PR TITLE
Use the 3.x version of Spire

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
     name := "vyxal",
     version := vyxalVersion,
     libraryDependencies ++= Seq(
-      ("org.typelevel" %%% "spire" % "0.18.0").cross(CrossVersion.for3Use2_13),
+      "org.typelevel" %%% "spire" % "0.18.0",
       "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.1.1",
       "org.scalactic" %%% "scalactic" % "3.2.14",
       "org.scalatest" %%% "scalatest" % "3.2.14" % Test


### PR DESCRIPTION
For some reason, I had set it to use the Scala 2.13 builds even though Spire targets Scala 3 itself.