### PR TITLE
Group arity-specific helpers together

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -10,6 +10,7 @@ rewrite.scala3.convertToNewSyntax = yes
 rewrite.scala3.removeOptionalBraces = yes
 # Insert an end marker if a function/class/whatever is longer than 15 lines
 rewrite.scala3.insertEndMarkerMinLines = 15
+rewrite.scala3.removeEndMarkerMaxLines = 14
 
 rewrite.rules = [Imports]
 rewrite.imports.sort = original

--- a/shared/src/main/scala/Context.scala
+++ b/shared/src/main/scala/Context.scala
@@ -32,6 +32,11 @@ class Context private (
 ):
   def settings: Settings = globals.settings
 
+  /** Pop the top of the stack
+    *
+    * If the stack's empty, get the next input (inputs repeat). If there are no
+    * inputs, read a line of input from stdin.
+    */
   def pop(): VAny =
     val elem =
       if stack.nonEmpty then stack.remove(stack.size - 1)
@@ -61,6 +66,7 @@ class Context private (
     // todo repeat the inputs or something?
     inputs.peek(numInput) ++ stack.slice(stack.length - numStack, stack.length)
 
+  /** Push an item onto the stack */
   def push(item: VAny): Unit = stack += item
 
   /** Whether the stack is empty */

--- a/shared/src/main/scala/Elements.scala
+++ b/shared/src/main/scala/Elements.scala
@@ -21,8 +21,10 @@ case class Element(
     impl: DirectFn
 )
 
-case class UnimplementedOverloadException(element: String, args: Any)
-    extends RuntimeException(s"$element not supported for inputs $args")
+case class UnimplementedOverloadException(element: String, args: Seq[VAny])
+    extends RuntimeException(
+      s"$element not supported for input(s) ${args.mkString("(", ", ", ")")}"
+    )
 
 object Elements:
   val elements: Map[String, Element] = Impls.elements.toMap
@@ -46,247 +48,74 @@ object Elements:
         () => ctx ?=> ctx.push(impl(using ctx))
       )
 
-    def addMonadHelper(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: Seq[String],
-        impl: Monad
-    ): Monad =
-      elements += symbol -> Element(
-        symbol,
-        name,
-        keywords,
-        Some(1),
-        vectorises,
-        overloads,
-        { () => ctx ?=>
-          ctx.push(impl(ctx.pop()))
-        }
-      )
-      impl
-    end addMonadHelper
-
     /** Add a monad that handles all `VAny`s (it doesn't take a
       * `PartialFunction`, hence "Full")
       */
-    def addMonadFull(
+    def addFull[F](
+        helper: ImplHelpers[?, F],
         symbol: String,
         name: String,
         keywords: Seq[String],
         vectorises: Boolean,
         overloads: String*
-    )(impl: VAny => Context ?=> VAny): Monad =
-      addMonadHelper(
-        symbol,
-        name,
-        keywords,
-        vectorises,
-        overloads,
-        impl
-      )
-
-    def addMonad(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: String*
-    )(impl: Context ?=> PartialFunction[VAny, VAny]): Monad =
-      addMonadHelper(
-        symbol,
-        name,
-        keywords,
-        vectorises,
-        overloads,
-        FuncHelpers.fillMonad(symbol, impl)
-      )
-
-      /** If using this method, make sure to use `case` to define the function,
-        * since it needs a `PartialFunction`. A normal function literal or one
-        * using underscores won't work, as those make normal `Function`s.
-        */
-    def addMonadVect(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        overloads: String*
-    )(impl: Context ?=> PartialFunction[VAny, VAny]): Monad =
-      addMonadHelper(
-        symbol,
-        name,
-        keywords,
-        true,
-        overloads,
-        vect1(symbol)(impl)
-      )
-
-    def addDyadHelper(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: Seq[String],
-        impl: Dyad
-    ): Dyad =
+    )(impl: F): Unit =
       elements += symbol -> Element(
         symbol,
         name,
         keywords,
-        Some(2),
+        Some(helper.arity),
         vectorises,
         overloads,
-        { () => ctx ?=>
-          val arg2, arg1 = ctx.pop()
-          ctx.push(impl(arg1, arg2))
-        }
-      )
-      impl
-    end addDyadHelper
-
-    /** Add a dyad that handles all `VAny`s */
-    def addDyadFull(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: String*
-    )(impl: Dyad): Dyad =
-      addDyadHelper(
-        symbol,
-        name,
-        keywords,
-        vectorises,
-        overloads,
-        impl
+        helper.toDirectFn(impl)
       )
 
-    /** Add a dyad that's defined using a bunch of `case`s. The `Partial` is
-      * because it can be a `PartialFunction`, meaning it may be undefined for
-      * some inputs. Because of this, `fillDyad` is used to "fill" the partial
-      * function and make it error on undefined inputs.
+    /** If using this method, make sure to use `case` to define the function,
+      * since it needs a `PartialFunction`. If it is possible to define it using
+      * a normal function literal, then try [[addFull]] instead.
       */
-    def addDyad(
+    def addElem[P, F](
+        helper: ImplHelpers[P, F],
         symbol: String,
         name: String,
         keywords: Seq[String],
         overloads: String*
-    )(impl: PartialVyFn[2]): Dyad =
-      addDyadHelper(
+    )(impl: P): F =
+      val full = helper.fill(symbol, impl)
+      elements += symbol -> Element(
         symbol,
         name,
         keywords,
+        Some(helper.arity),
         false,
         overloads,
-        FuncHelpers.fillDyad(symbol, impl)
+        helper.toDirectFn(full)
       )
+      full
+    end addElem
 
-    /** See [[addMonadVect]] for how to define `impl` */
-    def addDyadVect(
+    /** If using this method, make sure to use `case` to define the function,
+      * since it needs a `PartialFunction`. If it is possible to define it using
+      * a normal function literal, then try [[addFull]] instead.
+      */
+    def addVect[P, F](
+        helper: ImplHelpers[P, F],
         symbol: String,
         name: String,
         keywords: Seq[String],
         overloads: String*
-    )(impl: PartialVyFn[2]) =
-      addDyadHelper(
-        symbol,
-        name,
-        keywords,
-        true,
-        overloads,
-        vect2(symbol)(impl)
-      )
-
-    def addTriadHelper(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: Seq[String],
-        impl: VyFn[3]
-    ): Triad =
+    )(impl: P): F =
+      val vectorised = helper.vectorise(symbol)(impl)
       elements += symbol -> Element(
         symbol,
         name,
         keywords,
-        Some(3),
-        vectorises,
-        overloads,
-        { () => ctx ?=>
-          val arg3, arg2, arg1 = ctx.pop()
-          ctx.push(impl(arg1, arg2, arg3))
-        }
-      )
-      impl
-    end addTriadHelper
-
-    def addTriad(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        overloads: String*
-    )(impl: PartialVyFn[3]): Triad = addTriadHelper(
-      symbol,
-      name,
-      keywords,
-      false,
-      overloads,
-      FuncHelpers.fillTriad(name, impl)
-    )
-
-    /** See [[addMonadVect]] for how to define `impl` */
-    def addTriadVect(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        overloads: String*
-    )(impl: PartialVyFn[3]) =
-      addTriadHelper(
-        symbol,
-        name,
-        keywords,
+        Some(helper.arity),
         true,
         overloads,
-        vect3(symbol)(impl)
+        helper.toDirectFn(vectorised)
       )
-
-    def addTetradHelper(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        vectorises: Boolean,
-        overloads: Seq[String],
-        impl: VyFn[4]
-    ): Tetrad =
-      elements += symbol -> Element(
-        symbol,
-        name,
-        keywords,
-        Some(4),
-        vectorises,
-        overloads,
-        { () => ctx ?=>
-          val arg4, arg3, arg2, arg1 = ctx.pop()
-          ctx.push(impl(arg1, arg2, arg3, arg4))
-        }
-      )
-      impl
-    end addTetradHelper
-
-    def addTetrad(
-        symbol: String,
-        name: String,
-        keywords: Seq[String],
-        overloads: String*
-    )(impl: PartialVyFn[4]): Tetrad = addTetradHelper(
-      symbol,
-      name,
-      keywords,
-      false,
-      overloads,
-      FuncHelpers.fillTetrad(symbol, impl)
-    )
+      vectorised
+    end addVect
 
     /** Add an element that works directly on the entire stack */
     def addDirect(
@@ -306,7 +135,8 @@ object Elements:
         () => impl
       )
 
-    val add = addDyadFull(
+    addFull(
+      Dyad,
       "+",
       "Addition",
       List("add", "+", "plus"),
@@ -317,11 +147,11 @@ object Elements:
       "a: str, b: str -> a + b"
     )(MiscHelpers.add)
 
-    val allTruthy = addMonad(
+    val allTruthy = addElem(
+      Monad,
       "A",
       "All Truthy | All() | Is Vowel?",
       List("all", "is-vowel?"),
-      false,
       "a: str -> is (a) a vowel? vectorises for strings len > 1",
       "a: list -> is (a) all truthy?"
     ) {
@@ -338,7 +168,8 @@ object Elements:
         else 0
     }
 
-    val concatenate = addDyad(
+    val concatenate = addElem(
+      Dyad,
       "&",
       "Concatenate",
       List("concat", "&&", "append"),
@@ -348,10 +179,11 @@ object Elements:
       case (a: VList, b: VAny)  => VList(a :+ b*)
       case (a: VAny, b: VList)  => VList(a +: b*)
       case (a: VNum, b: VNum)   => VNum.from(f"$a$b")
-      case (a: VAny, b: VAny)   => add(a, b)
+      case (a: VAny, b: VAny)   => MiscHelpers.add(a, b)
     }
 
-    val convertFromBinary = addMonad(
+    addFull(
+      Monad,
       "B",
       "Convert From Binary",
       List("from-binary", "bin->dec", "bin->decimal"),
@@ -359,22 +191,20 @@ object Elements:
       "a: num -> str(a) from binary",
       "a: str -> int(a, 2)",
       "a: lst -> int(a, 2), using list of digits"
-    ) { case a: VAny =>
-      NumberHelpers.fromBinary(a)
-    }
+    )(NumberHelpers.fromBinary)
 
-    val convertToBinary = addMonad(
+    addFull(
+      Monad,
       "b",
       "Convert To Binary",
       List("to-binary", "dec->bin", "decimal->bin"),
       true,
       "a: num -> convert a to binary",
       "a: str -> bin(chr(x) for x in a)"
-    ) { case a: VAny =>
-      NumberHelpers.toBinary(a)
-    }
+    )(NumberHelpers.toBinary)
 
-    val count = addDyad(
+    val count = addElem(
+      Dyad,
       "C",
       "Count",
       List("count"),
@@ -386,7 +216,8 @@ object Elements:
         StringHelpers.countString(a.toString, b.toString)
     }
 
-    val divide = addDyadVect(
+    val divide = addVect(
+      Dyad,
       "÷",
       "Divide | Split",
       List("divide", "div", "split"),
@@ -404,7 +235,8 @@ object Elements:
         ctx.push(a)
     }
 
-    val equals = addDyadVect(
+    val equals = addVect(
+      Dyad,
       "=",
       "Equals",
       List("eq", "==", "equal", "same?", "equals?", "equal?"),
@@ -416,7 +248,8 @@ object Elements:
       case (a: String, b: String) => a == b
     }
 
-    val exponentation = addDyadVect(
+    val exponentation = addVect(
+      Dyad,
       "*",
       "Exponentation | Remove Nth Letter | Trim",
       List("exp", "**", "pow", "exponent", "remove-letter", "str-trim"),
@@ -443,11 +276,11 @@ object Elements:
       "a ->"
     ) { ctx ?=> ctx.pop() }
 
-    val execute = addMonad(
+    val execute = addElem(
+      Monad,
       "Ė",
       "Execute lambda | Evaluate as Vyxal | Power with base 10",
       List("execute-lambda", "evaluate-as-vyxal", "power-base-10"),
-      false,
       "a: fun -> Execute a",
       "a: str -> Evaluate a as Vyxal",
       "a: num -> 10 ** n"
@@ -459,7 +292,8 @@ object Elements:
       case n: VNum => 10 ** n
     }
 
-    val factorial = addMonadVect(
+    val factorial = addVect(
+      Monad,
       "!",
       "Factorial | To Uppercase",
       List("fact", "factorial", "to-upper", "upper", "uppercase", "!"),
@@ -497,7 +331,8 @@ object Elements:
         else ctx.settings.defaultValue
     }
 
-    val greaterThan = addDyadVect(
+    val greaterThan = addVect(
+      Dyad,
       ">",
       "Greater Than",
       List("gt", "greater", "greater-than", ">", "greater?", "bigger?"),
@@ -507,7 +342,8 @@ object Elements:
       "a: str, b: str -> a > b"
     ) { case (a: VVal, b: VVal) => MiscHelpers.compare(a, b) > 0 }
 
-    val lessThan: Dyad = addDyadVect(
+    val lessThan: Dyad = addVect(
+      Dyad,
       "<",
       "Less Than",
       List("lt", "less", "less-than", "<", "less?", "smaller?"),
@@ -517,7 +353,8 @@ object Elements:
       "a: str, b: str -> a < b"
     ) { case (a: VVal, b: VVal) => MiscHelpers.compare(a, b) < 0 }
 
-    val mapElement: Dyad = addDyad(
+    val mapElement: Dyad = addElem(
+      Dyad,
       "M",
       "Map Function | Mold Lists | Multiplicity",
       List("map", "mold", "multiplicity", "times-divide"),
@@ -534,7 +371,8 @@ object Elements:
         ListHelpers.map(a, ListHelpers.makeIterable(b, Some(true)))
     }
 
-    val modulo: Dyad = addDyadVect(
+    val modulo: Dyad = addVect(
+      Dyad,
       "%",
       "Modulo | String Formatting",
       List("mod", "modulo", "str-format", "format", "%"),
@@ -546,7 +384,8 @@ object Elements:
       case (a: VAny, b: String) => StringHelpers.formatString(b, a)
     }
 
-    val multiply = addDyadFull(
+    val multiply = addFull(
+      Dyad,
       "×",
       "Multiplication",
       List("mul", "multiply", "times", "str-repeat", "*", "ring-trans"),
@@ -557,7 +396,8 @@ object Elements:
       "a: str, b: str -> ring translate a according to b"
     ) { MiscHelpers.multiply(_, _) }
 
-    val negate = addMonadVect(
+    val negate = addVect(
+      Monad,
       "N",
       "Negation | Swap Case | First Non-Negative Integer Where Predicate is True",
       List(
@@ -579,7 +419,8 @@ object Elements:
     }
 
     val ordChr =
-      addMonadVect(
+      addVect(
+        Monad,
         "O",
         "Ord/Chr",
         List("ord", "chr"),
@@ -592,9 +433,10 @@ object Elements:
         case a: VNum => a.toInt.toChar.toString
       }
 
-    val pair = addDyadFull(";", "Pair", List("pair"), false, "a, b -> [a, b]") {
-      VList(_, _)
-    }
+    val pair =
+      addFull(Dyad, ";", "Pair", List("pair"), false, "a, b -> [a, b]") {
+        VList(_, _)
+      }
 
     val print = addDirect(
       ",",
@@ -606,7 +448,8 @@ object Elements:
       MiscHelpers.vyPrintln(ctx.pop())
     }
 
-    val reduction = addDyad(
+    val reduction = addElem(
+      Dyad,
       "R",
       "Reduce by Function Object | Dyadic Range | Regex Match",
       List(
@@ -634,7 +477,8 @@ object Elements:
         MiscHelpers.reduce(a, b)
     }
 
-    val subtraction = addDyadVect(
+    val subtraction = addVect(
+      Dyad,
       "-",
       "Subtraction",
       List(

--- a/shared/src/main/scala/FuncHelpers.scala
+++ b/shared/src/main/scala/FuncHelpers.scala
@@ -4,153 +4,47 @@ import vyxal.impls.UnimplementedOverloadException
 
 /** Helpers for function-related stuff */
 object FuncHelpers:
-
-  /** Take a monad and return a proper (not Partial) function that errors if
-    * it's not defined for the input
-    */
-  def fillMonad(
-      name: String,
-      fn: Context ?=> PartialFunction[VAny, VAny]
-  ): VAny => Context ?=> VAny = args =>
-    if fn.isDefinedAt(args) then fn(args)
-    else throw UnimplementedOverloadException(name, args)
-
-  /** Take a dyad and return a proper (not Partial) function that errors if it's
-    * not defined for the input
-    */
-  def fillDyad(name: String, fn: PartialVyFn[2]): Dyad = (a, b) =>
-    val args = (a, b)
-    if fn.isDefinedAt(args) then fn(args)
-    else throw UnimplementedOverloadException(name, args)
-
-  /** Take a triad and return a proper (not Partial) function that errors if
-    * it's not defined for the input
-    */
-  def fillTriad(name: String, fn: PartialVyFn[3]): Triad = (a, b, c) =>
-    val args = (a, b, c)
-    if fn.isDefinedAt(args) then fn(args)
-    else throw UnimplementedOverloadException(name, args)
-
-  /** Take a tetrad and return a proper (not Partial) function that errors if
-    * it's not defined for the input
-    */
-  def fillTetrad(name: String, fn: PartialVyFn[4]): Tetrad = (a, b, c, d) =>
-    val args = (a, b, c, d)
-    if fn.isDefinedAt(args) then fn(args)
-    else throw UnimplementedOverloadException(name, args)
-
+  /** Vectorise a function object */
   def vectorise(fn: VFun)(using ctx: Context): Unit =
-    if fn.arity == 1 then ctx.push(vectorise1(fn))
-    else if fn.arity == 2 then ctx.push(vectorise2(fn))
-    else if fn.arity == 3 then ???
-    else if fn.arity == 4 then ???
-    else
-      throw UnsupportedOperationException(
-        s"Vectorising functions of arity ${fn.arity} not possible"
-      )
+    val res =
+      fn.arity match
+        case 1 =>
+          val a = ctx.pop()
+          Monad.vectoriseNoFill { a =>
+            ctx.push(a)
+            Interpreter.executeFn(fn)
+          }(a)
+        case 2 =>
+          val b, a = ctx.pop()
+          Dyad.vectoriseNoFill { (a, b) =>
+            ctx.push(a)
+            ctx.push(b)
+            Interpreter.executeFn(fn)
+          }(a, b)
+        case 3 =>
+          val c, b, a = ctx.pop()
+          Triad.vectoriseNoFill { (a, b, c) =>
+            ctx.push(a)
+            ctx.push(b)
+            ctx.push(c)
+            Interpreter.executeFn(fn)
+          }(a, b, c)
+        case 4 =>
+          val d, c, b, a = ctx.pop()
+          Tetrad.vectoriseNoFill { (a, b, c, d) =>
+            ctx.push(a)
+            ctx.push(b)
+            ctx.push(c)
+            ctx.push(d)
+            Interpreter.executeFn(fn)
+          }(a, b, c, d)
+        case _ =>
+          throw UnsupportedOperationException(
+            s"Vectorising functions of arity ${fn.arity} not possible"
+          )
 
-  private def vectorise1(fn: VFun)(using ctx: Context): VAny =
-    ctx.pop() match
-      case lst: VList =>
-        lst.vmap { elem =>
-          ctx.push(elem)
-          vectorise1(fn)
-        }
-      case x =>
-        ctx.push(x)
-        Interpreter.executeFn(fn)
-
-  private def vectorise2(fn: VFun)(using ctx: Context): VAny =
-    val b, a = ctx.pop()
-
-    (a, b) match
-      case (a: VList, b: VList) =>
-        a.zipWith(b) { (x, y) =>
-          ctx.push(x)
-          ctx.push(y)
-          vectorise2(fn)
-        }
-      case (a: VList, b) =>
-        a.vmap { x =>
-          ctx.push(x)
-          ctx.push(b)
-          vectorise2(fn)
-        }
-      case (a, b: VList) =>
-        b.vmap { y =>
-          ctx.push(a)
-          ctx.push(y)
-          vectorise2(fn)
-        }
-      case (a, b) =>
-        ctx.push(a)
-        ctx.push(b)
-        Interpreter.executeFn(fn)
-    end match
-  end vectorise2
-
-  private def vectorise3(fn: VFun)(using ctx: Context): VAny =
-    val a = ctx.pop()
-    val b = ctx.pop()
-    val c = ctx.pop()
-
-    (a, b, c) match
-      case (a: VList, b: VList, c: VList) =>
-        VList.zipMulti(a, b, c) { case Seq(x, y, z) =>
-          ctx.push(x)
-          ctx.push(y)
-          ctx.push(z)
-          vectorise3(fn)
-        }
-      case (a: VList, b: VList, c) =>
-        a.zipWith(b) { (x, y) =>
-          ctx.push(x)
-          ctx.push(y)
-          ctx.push(c)
-          vectorise3(fn)
-        }
-      case (a: VList, b, c: VList) =>
-        a.zipWith(c) { (x, z) =>
-          ctx.push(x)
-          ctx.push(b)
-          ctx.push(z)
-          vectorise3(fn)
-        }
-      case (a, b: VList, c: VList) =>
-        b.zipWith(c) { (y, z) =>
-          ctx.push(a)
-          ctx.push(y)
-          ctx.push(z)
-          vectorise3(fn)
-        }
-      case (a: VList, b, c) =>
-        a.vmap { x =>
-          ctx.push(x)
-          ctx.push(b)
-          ctx.push(c)
-          vectorise3(fn)
-        }
-      case (a, b: VList, c) =>
-        b.vmap { y =>
-          ctx.push(a)
-          ctx.push(y)
-          ctx.push(c)
-          vectorise3(fn)
-        }
-      case (a, b, c: VList) =>
-        c.vmap { z =>
-          ctx.push(a)
-          ctx.push(b)
-          ctx.push(z)
-          vectorise3(fn)
-        }
-      case (a, b, c) =>
-        ctx.push(a)
-        ctx.push(b)
-        ctx.push(c)
-        Interpreter.executeFn(fn)
-    end match
-  end vectorise3
+    ctx.push(res)
+  end vectorise
 
   def reduceByElement(fn: VFun)(using ctx: Context): Unit =
     val iter = ctx.pop()

--- a/shared/src/main/scala/Functions.scala
+++ b/shared/src/main/scala/Functions.scala
@@ -8,49 +8,182 @@ type Dyad = (VAny, VAny) => Context ?=> VAny
 type Triad = (VAny, VAny, VAny) => Context ?=> VAny
 type Tetrad = (VAny, VAny, VAny, VAny) => Context ?=> VAny
 
-/** Make a function taking `Arity` VAnys TODO: Either merge this with Monad,
-  * Dyad, etc. or make this accept tuples like it used to
-  */
-type VyFn[Arity <: Int] = Arity match
-  case 1 => Monad
-  case 2 => Dyad
-  case 3 => Triad
-  case 4 => Tetrad
-// type VyFn[Arity <: Int] = TupleOfSize[Arity] => Context ?=> VAny
-
-/** Same as [[VyFn]] but may be undefined for some inputs */
-type PartialVyFn[Arity <: Int] =
-  Context ?=> PartialFunction[TupleOfSize[Arity], VAny]
-
-/** Make a tuple of size `N` filled with [[VAny]]s */
-private type TupleOfSize[N <: Int] <: Tuple = N match
-  case 0                        => EmptyTuple
-  case compiletime.ops.int.S[n] => VAny *: TupleOfSize[n]
+/** Like a [[Monad]], but doesn't accept all inputs */
+type PartialMonad = Context ?=> PartialFunction[VAny, VAny]
+type PartialDyad = Context ?=> PartialFunction[(VAny, VAny), VAny]
+type PartialTriad = Context ?=> PartialFunction[(VAny, VAny, VAny), VAny]
+type PartialTetrad = Context ?=> PartialFunction[(VAny, VAny, VAny, VAny), VAny]
 
 /** A function that operates directly on the stack */
 type DirectFn = () => Context ?=> Unit
 
-extension (f: Monad)
-  /** Turn the monad into a normal function of type `VAny => VAny` */
-  def norm(using ctx: Context): VAny => VAny = f(_)(using ctx)
+/** Meta-helper for creating the helpers to add element implementations
+  * @tparam P
+  *   The partial version of the function this helper group takes (`Context \=>
+  *   PartialFunction[(VAny, ...), VAny]`)
+  * @tparam F
+  *   The full version of the function (`(VAny, ...) => Context => VAny`)
+  */
+sealed abstract class ImplHelpers[P, F](val arity: Int):
+  /** Turn a completed implementation into a [[DirectFn]] */
+  def toDirectFn(impl: F): DirectFn
 
-  def vectorised =
+  /** Turn a partial implementation into a complete one
+    *
+    * The returned function throws an
+    * [[vyxal.impls.UnimplementedOverloadException]] when passed an argument for
+    * which it's not defined
+    */
+  def fill(symbol: String, impl: P): F
+
+  // TODO reduce duplication between these vectorisation functions and the ones in FuncHelpers.scala
+
+  /** Vectorise a function. There's no need to call [[fill]] first */
+  def vectorise(symbol: String)(impl: P): F =
+    vectoriseNoFill(fill(symbol, impl))
+
+  /** For subclasses to implement. Vectorise an implementation that's already
+    * been passed to [[fill]] and isn't a `PartialFunction` but doesn't actually
+    * work on lists.
+    */
+  protected def vectoriseNoFill(impl: F): F
+end ImplHelpers
+
+object Monad extends ImplHelpers[PartialMonad, Monad](1):
+  override def toDirectFn(impl: Monad) =
+    () => ctx ?=> ctx.push(impl(ctx.pop()))
+
+  override def fill(name: String, fn: PartialMonad) = arg =>
+    if fn.isDefinedAt(arg) then fn(arg)
+    else throw UnimplementedOverloadException(name, Seq(arg))
+
+  override def vectoriseNoFill(f: Monad) =
     lazy val res: Monad = {
       case lhs: VAtom => f(lhs)
       case lst: VList => lst.vmap(res)
     }
+
     res
+end Monad
 
-extension (f: Dyad)
-  /** Turn the dyad into a normal function of type `(VAny, VAny) => VAny` */
-  def norm(using ctx: Context): (VAny, VAny) => VAny =
-    f(_, _)(using ctx)
+object Dyad extends ImplHelpers[PartialDyad, Dyad](2):
+  override def toDirectFn(impl: Dyad): DirectFn =
+    () =>
+      ctx ?=> {
+        val arg2, arg1 = ctx.pop()
+        ctx.push(impl(arg1, arg2))
+      }
 
-extension (f: Triad)
-  /** Turn the triad into a normal function of type `(VAny, VAny, VAny) => VAny`
-    */
-  def norm(using ctx: Context): (VAny, VAny, VAny) => VAny =
-    f(_, _, _)(using ctx)
+  override def fill(name: String, fn: PartialDyad): Dyad = (a, b) =>
+    val args = (a, b)
+    if fn.isDefinedAt(args) then fn(args)
+    else throw UnimplementedOverloadException(name, args.toList)
+
+  override def vectoriseNoFill(f: Dyad): Dyad =
+    lazy val res: Dyad = {
+      case (lhs: VAtom, rhs: VAtom) => f(lhs, rhs)
+      case (lhs: VAtom, rhs: VList) => rhs.vmap(res(lhs, _))
+      case (lhs: VList, rhs: VAtom) => lhs.vmap(res(_, rhs))
+      case (lhs: VList, rhs: VList) => lhs.zipWith(rhs)(res(_, _))
+    }
+
+    res
+end Dyad
+
+object Triad extends ImplHelpers[PartialTriad, Triad](3):
+  override def toDirectFn(impl: Triad): DirectFn =
+    () =>
+      ctx ?=> {
+        val arg3, arg2, arg1 = ctx.pop()
+        ctx.push(impl(arg1, arg2, arg3))
+      }
+
+  override def fill(name: String, fn: PartialTriad): Triad = (a, b, c) =>
+    val args = (a, b, c)
+    if fn.isDefinedAt(args) then fn(args)
+    else throw UnimplementedOverloadException(name, args.toList)
+
+  override def vectoriseNoFill(f: Triad): Triad =
+    lazy val res: Triad = {
+      case (lhs: VAtom, rhs: VAtom, third: VAtom) => f(lhs, rhs, third)
+      case (lhs: VAtom, rhs: VList, third: VAtom) =>
+        rhs.vmap(res(lhs, _, third))
+      case (lhs: VList, rhs: VAtom, third: VAtom) =>
+        lhs.vmap(res(_, rhs, third))
+      case (lhs: VList, rhs: VList, third: VAtom) =>
+        lhs.zipWith(rhs)(res(_, _, third))
+      case (lhs: VAtom, rhs: VAtom, third: VList) =>
+        third.vmap(res(lhs, rhs, _))
+      case (lhs: VAtom, rhs: VList, third: VList) =>
+        rhs.zipWith(third)(res(lhs, _, _))
+      case (lhs: VList, rhs: VAtom, third: VList) =>
+        lhs.zipWith(third)(res(_, rhs, _))
+      case (lhs: VList, rhs: VList, third: VList) =>
+        VList.zipMulti(lhs, rhs, third) { case VList(l, r, t) => res(l, r, t) }
+    }
+
+    res
+  end vectoriseNoFill
+end Triad
+
+object Tetrad extends ImplHelpers[PartialTetrad, Tetrad](4):
+  override def toDirectFn(impl: Tetrad): DirectFn =
+    () =>
+      ctx ?=> {
+        val arg4, arg3, arg2, arg1 = ctx.pop()
+        ctx.push(impl(arg1, arg2, arg3, arg4))
+      }
+
+  override def fill(name: String, fn: PartialTetrad): Tetrad = (a, b, c, d) =>
+    val args = (a, b, c, d)
+    if fn.isDefinedAt(args) then fn(args)
+    else throw UnimplementedOverloadException(name, args.toList)
+
+  override def vectoriseNoFill(f: Tetrad) =
+    lazy val res: Tetrad = {
+      case (as: VList, bs: VList, cs: VList, ds: VList) =>
+        VList.zipMulti(as, bs, cs, ds) { case VList(a, b, c, d) =>
+          res(a, b, c, d)
+        }
+      case (a, bs: VList, cs: VList, ds: VList) =>
+        VList.zipMulti(bs, cs, ds) { case VList(b, c, d) =>
+          res(a, b, c, d)
+        }
+
+      case (as: VList, b, cs: VList, ds: VList) =>
+        VList.zipMulti(as, cs, ds) { case VList(a, c, d) =>
+          res(a, b, c, d)
+        }
+      case (as: VList, bs: VList, c, ds: VList) =>
+        VList.zipMulti(as, bs, ds) { case VList(a, b, d) =>
+          res(a, b, c, d)
+        }
+      case (as: VList, bs: VList, cs: VList, d) =>
+        VList.zipMulti(as, bs, cs) { case VList(a, b, c) =>
+          res(a, b, c, d)
+        }
+      case (a, b, cs: VList, ds: VList) =>
+        cs.zipWith(ds) { (c, d) => res(a, b, c, d) }
+      case (a, bs: VList, c, ds: VList) =>
+        bs.zipWith(ds) { (b, d) => res(a, b, c, d) }
+      case (a, bs: VList, cs: VList, d) =>
+        bs.zipWith(cs) { (b, c) => res(a, b, c, d) }
+      case (as: VList, b, c, ds: VList) =>
+        as.zipWith(ds) { (a, d) => res(a, b, c, d) }
+      case (as: VList, b, cs: VList, d) =>
+        as.zipWith(cs) { (a, c) => res(a, b, c, d) }
+      case (as: VList, bs: VList, c, d) =>
+        as.zipWith(bs) { (a, b) => res(a, b, c, d) }
+      case (a: VList, b, c, d) => a.vmap(res(_, b, c, d))
+      case (a, b: VList, c, d) => b.vmap(res(a, _, c, d))
+      case (a, b, c: VList, d) => c.vmap(res(a, b, _, d))
+      case (a, b, c, d: VList) => d.vmap(res(a, b, c, _))
+      case (a, b, c, d)        => f(a, b, c, d)
+    }
+
+    res
+  end vectoriseNoFill
+end Tetrad
 
 /** Make a partial function that only works on non-functions act kinda like an
   * APL fork when given functions as arguments.
@@ -64,7 +197,7 @@ extension (f: Triad)
   *   - If the arguments are a function `f` and a value `b`, then it applies
   *     `impl` to the result of `f` and `b`
   */
-def forkify(impl: PartialVyFn[2]): PartialVyFn[2] = {
+def forkify(impl: PartialDyad): PartialDyad = {
   case (a, b) if impl.isDefinedAt((a, b)) => impl(a, b)
   case (f: VFun, g: VFun) =>
     VFun(
@@ -101,58 +234,3 @@ def forkify(impl: PartialVyFn[2]): PartialVyFn[2] = {
       summon[Context]
     )
 }
-
-// TODO reduce duplication between these functions and the ones in FuncHelpers.scala
-
-/** Vectorise an unvectorised monad */
-def vect1(name: String)(f: Context ?=> PartialFunction[VAny, VAny]): Monad =
-  val filled = FuncHelpers.fillMonad(name, f)
-  lazy val res: Monad = {
-    case lhs: VAtom => filled(lhs)
-    case lst: VList => lst.vmap(res)
-  }
-
-  res
-
-/** Vectorise an unvectorised dyad */
-def vect2(name: String)(f: PartialVyFn[2]): Dyad =
-  val filled = FuncHelpers.fillDyad(name, f)
-  lazy val res: Dyad = {
-    case (lhs: VAtom, rhs: VAtom) => filled(lhs, rhs)
-    case (lhs: VAtom, rhs: VList) => rhs.vmap(res(lhs, _))
-    case (lhs: VList, rhs: VAtom) => lhs.vmap(res(_, rhs))
-    case (lhs: VList, rhs: VList) => lhs.zipWith(rhs)(res(_, _))
-  }
-
-  res
-
-/** Vectorise a triad */
-def vect3(name: String)(f: PartialVyFn[3]): VyFn[3] =
-  val filled = FuncHelpers.fillTriad(name, f)
-  lazy val res: VyFn[3] = {
-    case (lhs: VAtom, rhs: VAtom, third: VAtom) => filled(lhs, rhs, third)
-    case (lhs: VAtom, rhs: VList, third: VAtom) => rhs.vmap(res(lhs, _, third))
-    case (lhs: VList, rhs: VAtom, third: VAtom) => lhs.vmap(res(_, rhs, third))
-    case (lhs: VList, rhs: VList, third: VAtom) =>
-      lhs.zipWith(rhs)(res(_, _, third))
-    case (lhs: VAtom, rhs: VAtom, third: VList) => third.vmap(res(lhs, rhs, _))
-    case (lhs: VAtom, rhs: VList, third: VList) =>
-      rhs.zipWith(third)(res(lhs, _, _))
-    case (lhs: VList, rhs: VAtom, third: VList) =>
-      lhs.zipWith(third)(res(_, rhs, _))
-    case (lhs: VList, rhs: VList, third: VList) =>
-      VList.zipMulti(lhs, rhs, third) { zipped =>
-        (zipped: @unchecked) match
-          case VList(l, r, t) =>
-            f(
-              l.asInstanceOf[VAtom],
-              r.asInstanceOf[VAtom],
-              t.asInstanceOf[VAtom]
-            )
-      }
-  }
-
-  res
-end vect3
-
-// TODO: add vect4

--- a/shared/src/main/scala/Globals.scala
+++ b/shared/src/main/scala/Globals.scala
@@ -61,7 +61,7 @@ class Inputs(origInputs: Seq[VAny] = Seq.empty):
     val nonWrapping = currInputs.slice(ind, ind + numNonWrapping + 1).toList
 
     if n <= numNonWrapping then nonWrapping
-    else {
+    else
       // The number of times the entire inputs array has to be repeated
       val numRepeats = (n - numNonWrapping) / currInputs.size
       val repeats = List.fill(numRepeats)(currInputs.toList)
@@ -71,7 +71,6 @@ class Inputs(origInputs: Seq[VAny] = Seq.empty):
       val end = currInputs.take(numEnd).toList
 
       nonWrapping ::: repeats.flatten ::: end
-    }
   end peek
 end Inputs
 

--- a/shared/src/main/scala/MiscHelpers.scala
+++ b/shared/src/main/scala/MiscHelpers.scala
@@ -9,7 +9,7 @@ import spire.algebra.*
 
 object MiscHelpers:
   // todo consider doing something like APL's forks so this doesn't have to be a partial function
-  val add = vect2("add")(forkify {
+  val add = Dyad.vectorise("add")(forkify {
     case (a: VNum, b: VNum)     => a + b
     case (a: String, b: VNum)   => s"$a$b"
     case (a: VNum, b: String)   => s"$a$b"
@@ -37,7 +37,7 @@ object MiscHelpers:
       i += 1
     ???
 
-  val multiply = vect2("multiply") {
+  val multiply = Dyad.vectorise("multiply") {
     case (a: VNum, b: VNum)     => a * b
     case (a: String, b: VNum)   => a * b.toInt
     case (a: VNum, b: String)   => b * a.toInt
@@ -94,7 +94,6 @@ object MiscHelpers:
           nameStack.top += temp
         nameStack.top += name
       depth = varDepth
-    end for
     for i <- 0 until depth do
       val temp = VList(nameStack.pop().toList*)
       nameStack.top += temp

--- a/shared/src/main/scala/Parser.scala
+++ b/shared/src/main/scala/Parser.scala
@@ -385,10 +385,8 @@ object Parser:
               case VyxalToken.StructureAllClose               => depth -= 1
               case _                                          => None
             contents.++=(top.value)
-          end while
           processed += VyxalToken.UnpackVar(contents.toString())
         case _ => processed += temp
-      end match
     end while
     processed.toList
   end preprocess
@@ -402,7 +400,6 @@ object Parser:
       }
       case _ => asts
     temp
-  end postprocess
 
   private def isNilad(ast: AST) =
     ast match

--- a/shared/src/main/scala/StringHelpers.scala
+++ b/shared/src/main/scala/StringHelpers.scala
@@ -28,9 +28,7 @@ object StringHelpers:
     sb.toString
   end formatString
 
-  def isVowel(c: String): VNum = c.toLowerCase() match
-    case "a" | "e" | "i" | "o" | "u" => 1
-    case _                           => 0
+  def isVowel(c: Char): VNum = "aeiouAEIOU".contains(c)
 
   /** Remove the character at the given index */
   def remove(s: String, i: Int): String =

--- a/shared/src/main/scala/StringHelpers.scala
+++ b/shared/src/main/scala/StringHelpers.scala
@@ -19,14 +19,12 @@ object StringHelpers:
         if i + 1 < fmtstr.length && fmtstr(i + 1) == '%' then
           sb.append('%')
           i += 2
-        else {
+        else
           sb.append(args(j % args.length))
           i += 1
-        }
-      else {
+      else
         sb.append(fmtstr(i))
         i += 1
-      }
     sb.toString
   end formatString
 

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -15,14 +15,7 @@ class ElementTests extends AnyFunSpec:
         ctx.push(VList(VList(2, 5), "foo"))
         ctx.push(VList(VList(3, 4)))
         Interpreter.execute(AST.Command("+"))
-        assertResult(
-          VList(
-            VList(5, 9),
-            "foo0"
-          )
-        )(
-          ctx.pop()
-        )
+        assertResult(VList(VList(5, 9), "foo0"))(ctx.pop())
       }
     }
     describe("when given functions") {
@@ -52,9 +45,7 @@ class ElementTests extends AnyFunSpec:
     describe("when given two lists") {
       it("should mold them properly") {
         given Context = Context()
-        assertResult(
-          VList(1, 2, VList(VList(VList(3, 4), 5, 1), 2))
-        )(
+        assertResult(VList(1, 2, VList(VList(VList(3, 4), 5, 1), 2)))(
           Impls.mapElement(
             VList(1, 2, VList(3, 4), 5),
             VList(1, 2, VList(VList(3, 4, 6), 5))

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -11,14 +11,17 @@ class ElementTests extends AnyFunSpec:
   describe("Element +") {
     describe("when given lists") {
       it("should vectorise properly") {
-        given Context = Context()
+        given ctx: Context = Context()
+        ctx.push(VList(VList(2, 5), "foo"))
+        ctx.push(VList(VList(3, 4)))
+        Interpreter.execute(AST.Command("+"))
         assertResult(
           VList(
             VList(5, 9),
             "foo0"
           )
         )(
-          Impls.add(VList(VList(2, 5), "foo"), VList(VList(3, 4)))
+          ctx.pop()
         )
       }
     }
@@ -36,7 +39,9 @@ class ElementTests extends AnyFunSpec:
           )
         )
         ctx.push(3)
-        ctx.push(Impls.add(f, g))
+        ctx.push(f)
+        ctx.push(g)
+        Interpreter.execute(AST.Command("+"))
         Interpreter.execute(AST.ExecuteFn)
         assertResult(VNum(1))(ctx.pop())
       }


### PR DESCRIPTION
This PR was originally just meant to group `addX` and `addXVect` together (hence the branch name) and change their signatures to take the overloads as a single multiline string instead of a list of strings, but I ended up making `Monad`, `Dyad`, `Triad`, `Tetrad` objects extending an `ImplHelpers` class that groups `vectorise`, `fill`, and `toDirectFn` together for each arity. This makes it so a single `addFull` method can be used for all arities, a single `addVect` can be used for all arities, etc. I think this is a better solution, since we can continue making elements almost exactly the same way as before, but there's less code duplication.

I also rewrote the `vectorise` method in `FuncHelpers` (that one operates on function objects/`VFun`s, not `Monad`s, `Dyad`s, etc.). It was the code used for vectorising the element implementations, so I made it just call `Monad.vectorise`, `Dyad.vectorise`, etc. It was really bugging me and I couldn't wait for another PR to get rid of that extra code.

Other minor changes:
- Got rid of `VyFn` and `PartialVyFn` because they weren't too necessary and used advanced-ish features that would likely produce hard-to-understand error messages if used incorrectly
- Changed scalafmt settings to also remove end markers if the block is too short, in case we refactor a long function to be shorter
- <s>Made `addFull` not return anything. I figured since the function's already defined elsewhere, you don't need another copy of it. Let me know if it should be changed back to the old behavior (returning the function impl that was passed in)</s>

The name `ImplHelpers` isn't great, so if someone has suggestions on something to rename it to that describes its purpose better, that'd be great.