### PR TITLE
Add scalafix

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Lint with Scalafix
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    - name: Lint
+      run: sbt vyxalJVM/scalafixAll --check

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,39 @@
+rules = [
+  DisableSyntax,
+  RedundantSyntax,
+  NoAutoTupling
+]
+
+DisableSyntax.noNulls = true
+DisableSyntax.noFinalVal = true
+DisableSyntax.regex = [
+  {
+    id = "CaseBraces"
+    pattern = "case.*=>\\s*(\\{)"
+    message = "No need for {} for cases (even with the old syntax)"
+  }
+  {
+    id = "BooleanToVNum"
+    regex = {
+      pattern = "if (.+) then[\\s\\n]+1[\\s\\n]+else[\\s\\n]+0"
+      captureGroup = 1
+    }
+    message = "Import VNum.given and use {$1} directly instead of explicitly converting Booleans to VNums"
+  }
+  {
+    id = "MatchingVAny"
+    regex = {
+      pattern = "case.*(: VAny)"
+      captureGroup = 1
+    }
+    message = "It's unnecessary to check if an argument is a VAny, since all Vyxal objects are VAnys"
+  }
+  {
+    id = "EmptyCheck"
+    regex = {
+      pattern = "\\.((size|length)[\\s\\n]+[!=]=[\\s\\n]+0)"
+      captureGroup = 1
+    }
+    message = "Use .isEmpty or .nonEmpty instead"
+  }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
     // Shared settings
     name := "vyxal",
     version := vyxalVersion,
+    semanticdbEnabled := true,
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "spire" % "0.18.0",
       "org.scala-lang.modules" %%% "scala-parser-combinators" % "2.1.1",
@@ -52,8 +53,7 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
       "-language:implicitConversions",
       "-language:adhocExtensions",
       // "-explain",
-      "-print-lines",
-      "-Yno-adapted-args"
+      "-print-lines"
     ),
     // Configure Scaladoc
     Compile / doc / target := file("docs"),

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
       "-language:adhocExtensions",
       // "-explain",
       "-print-lines",
-      "-Ycheck-all-patmat"
+      "-Yno-adapted-args"
     ),
     // Configure Scaladoc
     Compile / doc / target := file("docs"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,9 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
+// For making an uber JAR
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
+// For auto-formatting
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
+// For linting
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")

--- a/shared/src/main/scala/Parser.scala
+++ b/shared/src/main/scala/Parser.scala
@@ -130,7 +130,7 @@ object Parser:
                   s"Modifier $name not defined for $modifierArgs"
                 )
               )
-        case AST.SpecialModifier(name) => {
+        case AST.SpecialModifier(name) =>
           (name: @unchecked) match
             case "ᵜ" =>
               val lambdaAsts = ListBuffer[AST]()
@@ -144,7 +144,6 @@ object Parser:
                 )
               )
             case "ᵗ" => ??? // TODO: Implement tie
-        }
         case AST.AuxAugmentVar(name) =>
           if asts.isEmpty then
             return Left(
@@ -395,11 +394,10 @@ object Parser:
 
   private def postprocess(asts: AST): AST =
     val temp = asts match
-      case AST.Group(elems, _) => {
+      case AST.Group(elems, _) =>
         val nilads = elems.reverse.takeWhile(isNilad).reverse
         val rest = elems.dropRight(nilads.length)
         AST.Group(nilads ++ rest, None)
-      }
       case _ => asts
     temp
   end postprocess


### PR DESCRIPTION
[Scalafix](https://scalacenter.github.io/scalafix/) is a linting/refactoring tool. It doesn't yet support a lot of rules for Scala 3, but eventually we'll be able to use it to remove unused imports and stuff. I also added a few rules for common mistakes someone new to Scala or the Vyxal codebase might make:

- `CaseBraces` - To warn people that braces aren't needed when they do `case foo => {}`
- `EmptyCheck` - To warn people that `foo.isEmpty` and `foo.nonEmpty` can be used instead of comparing `foo.size`/`foo.length` to 0
- `BooleanToVNum` (Vyxal-specific) - To warn people that explicitly converting booleans to `VNum`s isn't necessary (`if bool then 1 else 0`)
- `MatchingVAny` (Vyxal-specific) - To warn people that it's not necessary to match on `VAny` since all the objects we deal with are `VAny`s (`case foo: VAny`)


Later on, we could add more custom rules to make our code style more uniform and to help out anyone new to Vyxal.

Take a look at the output from Scalafix on this PR [here](https://github.com/Vyxal/Vyxal/actions/runs/3952540068/jobs/6767744944).