### PR TITLE
Make Context#push variadic

### DIFF
--- a/shared/src/main/scala/Context.scala
+++ b/shared/src/main/scala/Context.scala
@@ -66,8 +66,8 @@ class Context private (
     // todo repeat the inputs or something?
     inputs.peek(numInput) ++ stack.slice(stack.length - numStack, stack.length)
 
-  /** Push an item onto the stack */
-  def push(item: VAny): Unit = stack += item
+  /** Push items onto the stack. The first argument will be pushed first. */
+  def push(items: VAny*): Unit = stack ++= items
 
   /** Whether the stack is empty */
   def isStackEmpty: Boolean = stack.isEmpty
@@ -175,7 +175,7 @@ object Context:
       popArgs: Boolean
   ) =
     val newInputs = args
-      .map(_.toList)
+      .map(_.toList.reverse)
       .getOrElse(if popArgs then currCtx.pop(arity) else currCtx.peek(arity))
     if currCtx.settings.logLevel == LogLevel.Debug then
       println(

--- a/shared/src/main/scala/Elements.scala
+++ b/shared/src/main/scala/Elements.scala
@@ -230,8 +230,7 @@ object Elements:
     val dup = addDirect(":", "Duplicate", List("dup"), None, "a -> a, a") {
       ctx ?=>
         val a = ctx.pop()
-        ctx.push(a)
-        ctx.push(a)
+        ctx.push(a, a)
     }
 
     // todo extract to helper in MiscHelpers?
@@ -507,19 +506,15 @@ object Elements:
 
     val swap = addDirect("$", "Swap", List("swap"), None, "a, b -> b, a") {
       ctx ?=>
-        val b = ctx.pop()
-        val a = ctx.pop()
-        ctx.push(b)
-        ctx.push(a)
+        val b, a = ctx.pop()
+        ctx.push(b, a)
     }
 
     val triplicate =
       addDirect("D", "Triplicate", List("trip"), None, "a -> [a, a, a]") {
         ctx ?=>
           val a = ctx.pop()
-          ctx.push(a)
-          ctx.push(a)
-          ctx.push(a)
+          ctx.push(a, a, a)
       }
 
     val vectoriseAsElement = addDirect(

--- a/shared/src/main/scala/FuncHelpers.scala
+++ b/shared/src/main/scala/FuncHelpers.scala
@@ -11,32 +11,22 @@ object FuncHelpers:
         case 1 =>
           val a = ctx.pop()
           Monad.vectoriseNoFill { a =>
-            ctx.push(a)
-            Interpreter.executeFn(fn)
+            Interpreter.executeFn(fn, args = Some(List(a)))
           }(a)
         case 2 =>
           val b, a = ctx.pop()
           Dyad.vectoriseNoFill { (a, b) =>
-            ctx.push(a)
-            ctx.push(b)
-            Interpreter.executeFn(fn)
+            Interpreter.executeFn(fn, args = Some(List(a, b)))
           }(a, b)
         case 3 =>
           val c, b, a = ctx.pop()
           Triad.vectoriseNoFill { (a, b, c) =>
-            ctx.push(a)
-            ctx.push(b)
-            ctx.push(c)
-            Interpreter.executeFn(fn)
+            Interpreter.executeFn(fn, args = Some(List(a, b, c)))
           }(a, b, c)
         case 4 =>
           val d, c, b, a = ctx.pop()
           Tetrad.vectoriseNoFill { (a, b, c, d) =>
-            ctx.push(a)
-            ctx.push(b)
-            ctx.push(c)
-            ctx.push(d)
-            Interpreter.executeFn(fn)
+            Interpreter.executeFn(fn, args = Some(List(a, b, c, d)))
           }(a, b, c, d)
         case _ =>
           throw UnsupportedOperationException(

--- a/shared/src/test/scala/ElementTests.scala
+++ b/shared/src/test/scala/ElementTests.scala
@@ -12,8 +12,7 @@ class ElementTests extends AnyFunSpec:
     describe("when given lists") {
       it("should vectorise properly") {
         given ctx: Context = Context()
-        ctx.push(VList(VList(2, 5), "foo"))
-        ctx.push(VList(VList(3, 4)))
+        ctx.push(VList(VList(2, 5), "foo"), VList(VList(3, 4)))
         Interpreter.execute(AST.Command("+"))
         assertResult(VList(VList(5, 9), "foo0"))(ctx.pop())
       }
@@ -31,9 +30,7 @@ class ElementTests extends AnyFunSpec:
             AST.makeSingle(AST.Number(8), AST.Command("-"))
           )
         )
-        ctx.push(3)
-        ctx.push(f)
-        ctx.push(g)
+        ctx.push(3, f, g)
         Interpreter.execute(AST.Command("+"))
         Interpreter.execute(AST.ExecuteFn)
         assertResult(VNum(1))(ctx.pop())
@@ -103,8 +100,7 @@ class ElementTests extends AnyFunSpec:
     describe("when given a function") {
       it("should execute the function") {
         given ctx: Context = Context()
-        ctx.push(1)
-        ctx.push(2)
+        ctx.push(1, 2)
         assertResult(3: VNum)(
           Impls.execute(VFun.fromElement(Elements.elements("+")))
         )

--- a/shared/src/test/scala/InterpreterTests.scala
+++ b/shared/src/test/scala/InterpreterTests.scala
@@ -37,8 +37,7 @@ class InterpreterTests extends AnyFunSuite:
 
   test("Can the interpreter execute named functions?") {
     given ctx: Context = Context()
-    ctx.push(3)
-    ctx.push(4)
+    ctx.push(3, 4)
     Interpreter.execute(AST.FnDef("f", AST.Lambda(2, List.empty, AST.Command("-"))))
     Interpreter.execute(AST.GetVar("f"))
     Interpreter.execute(AST.Command("Ė"))
@@ -83,8 +82,7 @@ class InterpreterTests extends AnyFunSuite:
 
   test("Can the interpreter vectorise dyadic lambdas?") {
     given ctx: Context = Context()
-    ctx.push(VList(0, 3, VList(2, 1)))
-    ctx.push(VList(4, 2, 6))
+    ctx.push(VList(0, 3, VList(2, 1)), VList(4, 2, 6))
     Interpreter.execute(
       Modifiers
         .modifiers("v")


### PR DESCRIPTION
Steffan suggested making it variadic so we won't have to do things like `ctx.push(a); ctx.push(b); ctx.push(c)`. Also fixed a minor issue in `Context.makeFnCtx` where if you explicitly gave arguments for a function to use (instead of popping them from the stack), it would give them in the reverse order.