### PR TITLE
fix incorrect behavior of multiline comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vyxal
 
-<!-- secret hidden comment from a bot test--> 
+<!-- secret hidden comment from a bot test-->
 
 ![Vyxal Logo](./documents/logo/vylogo.png)
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -23,6 +23,7 @@ def token_equal(source: str, expected: list[Token]) -> bool:
         expected list have the same name and value
     """
 
+    print(tokenise(source))
     return all(
         map(
             lambda x: x[0] == x[1],
@@ -123,11 +124,14 @@ def test_variables():
     )
 
 
-if __name__ == "__main__":
-    test_single_token()
-    test_one_plus_one()
-    test_strings()
-    test_comments()
-    test_numbers()
-    test_variables()
-    print("everything passed.")
+def test_multiline_comments():
+    assert token_equal("#{}##{\n1", [])
+    assert token_equal(
+        "#{}#{ }#\n1",
+        [
+            Token(TokenType.GENERAL, "{"),
+            Token(TokenType.GENERAL, " "),
+            Token(TokenType.GENERAL, "}"),
+            Token(TokenType.NUMBER, "1"),
+        ],
+    )

--- a/vyxal/lexer.py
+++ b/vyxal/lexer.py
@@ -161,8 +161,10 @@ def tokenise(
                 while source:
                     h = source.popleft()
                     if h == "#" and source[0] == "{":
+                        source.popleft()
                         depth += 1
                     if h == "}" and source[0] == "#":
+                        source.popleft()
                         depth -= 1
                         if depth == 0:
                             break


### PR DESCRIPTION
`#` in `}#` does not get eaten, that's why:
This program prints 1, should print 0:
```
#{}##{
1
```
This program prints 1, should hang:
```
#{}#{ }#
1
```
**Warning**: I did not test this PR because I could not figure out how to run development version.