### PR TITLE
Fix `IndexError: deque index out of range` while lexing unclosed multiline comment

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -135,3 +135,5 @@ def test_multiline_comments():
             Token(TokenType.NUMBER, "1"),
         ],
     )
+    assert token_equal("#{#", [])
+    assert token_equal("#{}", [])

--- a/vyxal/lexer.py
+++ b/vyxal/lexer.py
@@ -160,10 +160,10 @@ def tokenise(
                 depth = 1
                 while source:
                     h = source.popleft()
-                    if h == "#" and source[0] == "{":
+                    if h == "#" and source and source[0] == "{":
                         source.popleft()
                         depth += 1
-                    if h == "}" and source[0] == "#":
+                    if h == "}" and source and source[0] == "#":
                         source.popleft()
                         depth -= 1
                         if depth == 0:


### PR DESCRIPTION
This PR fixes these programs: `#{#` and `#{}`