### PR TITLE
Make scoping work like Python

### DIFF
--- a/documentation/Interpreter.md
+++ b/documentation/Interpreter.md
@@ -31,7 +31,7 @@ After parsing, the result is an `AST.Group`, which is an AST object that contain
 | `AST.Group`          | Each AST in the group is executed individually | ❌ |
 | `AST.CompositeNilad` | Same as `AST.Group`. This AST type is for arity grouping purposes. | ❌ |
 | `AST.If`             | Pop the top of the stack, truthy: execute truthy branch, else: execute falsey branch if present | ❌ |
-| `AST.While` | While the condition branch evaluated on the stack is truthy, execute the loop body. | ✅<br><br>`N` = Number of while loop iterations<br>`M` = Last condition value  |
+| `AST.While` | While the condition branch evaluated on the stack is truthy, execute the loop body. | ✅<br><br>`N` = Last condition value<br>`M` = Number of while loop iterations (current loop index) |
 | `AST.For`            | Pop the top of the stack, cast to iterable, and execute body loop for each item in that. | ✅<br><br>`N` = Current loop item<br>`M` = Current loop index |
 | `AST.Lambda`         | Push a `VFun` object to the stack that represents the lambda | ❌(no context variable is set when pushing, but context variable may be set when executing function) |
 | `AST.FnDef`          | Set variable equivalent to function name to lambda that represents function body | ❌ |

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -28,3 +28,11 @@ TODO
 ### Context Variables
 
 Context variables are TODO
+
+### Ghost variable
+
+The so-called ghost variable is the variable named ``. You can get and set it just like a normal
+variable. Of course, you need to make sure there aren't any valid identifier characters after the
+`#$` / `#=` like `#$a1`, or the parser will think you're referring to some variable `a1`. If you're
+already using the register, the ghost variable is a good way to store something off the stack
+without using up too many characters. Just keep the limitation above in mind.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -27,7 +27,12 @@ TODO
 
 ### Context Variables
 
-Context variables are TODO
+Vyxal has 2 context variables, `N` and `M`. They hold different values inside different
+structures:
+
+- Inside for loops, `N` is the current value, and `M` is the current index
+- Inside while loops, `N` is the last condition value and `M` is the current index
+- Inside lambdas/named functions, `N` is the argument
 
 ### Ghost variable
 


### PR DESCRIPTION
This PR makes the parent context of an executing lambda the context that it was originally created in instead of the context it's executing in, so that it has full access to the variables from there. This doesn't work *exactly* like Python, since it's a bit like `nonlocal x` is automatically thrown in whenever you use a variable `x` from the outer context, but I think it's the same as Vyxal v2's behavior.

After discussing with lyxal in chat, context variable N is now last condition value in while loops and context variable M is the while loop's index (they were swapped). I've updated comments and docs a bit, let me know if I put it wrong.

Also added some miscellaneous changes, since we don't have too many people to review PRs and I'm lazy.