### PR TITLE
Make decimals and complex literals work better

### DIFF
--- a/shared/src/main/scala/Lexer.scala
+++ b/shared/src/main/scala/Lexer.scala
@@ -63,9 +63,10 @@ object Lexer extends RegexParsers:
   override def skipWhitespace = true
   override val whiteSpace: Regex = "[ \t\r\f]+".r
 
-  def number: Parser[VyxalToken] = """(0(?=[^.ı])|\d+(\.\d*)?(\ı\d*)?)""".r ^^ {
-    value => Number(value)
-  }
+  def number: Parser[VyxalToken] =
+    """(0(?=[^.ı])|\d*\.\d*(ı(\d*\.\d*|\d+)?)?|\.|ı|\d+)""".r ^^ { value =>
+      Number(value)
+    }
 
   def string: Parser[VyxalToken] = """("(?:[^"„”“\\\\]|\\.)*["„”“])""".r ^^ {
     value =>

--- a/shared/src/main/scala/VNum.scala
+++ b/shared/src/main/scala/VNum.scala
@@ -46,14 +46,16 @@ object VNum:
     // Spits into real and imaginary parts
     // todo handle empty real part
     val parts = s.split("ı")
-    val real = parts(0)
-    val imag = parts.lift(1).getOrElse("0")
+    val real = parts.lift(0).getOrElse("0")
+    val imag = if s.endsWith("ı") then "1" else parts.lift(1).getOrElse("0")
 
-    val realNum = (if real.last == '.' then real + "5" else real).toInt
-    val imagNum = (if imag.last == '.' then imag + "5" else imag).toInt
+    var realNum: String = if real.last == '.' then real + "5" else real
+    realNum = if realNum.startsWith(".") then "0" + realNum else realNum
+    var imagNum: String = if imag.last == '.' then imag + "5" else imag
+    imagNum = if imagNum.startsWith(".") then "0" + imagNum else imagNum
 
-    if imagNum == 0 then complex(realNum, 0)
-    else complex(realNum, imagNum)
+    if Real(imagNum) == 0 then complex(Real(realNum), 0)
+    else complex(Real(realNum), Real(imagNum))
   end from
 
   /** Allow pattern matching like `VNum(r, i)` */
@@ -66,6 +68,7 @@ object VNum:
   given Conversion[Double, VNum] = n => complex(n, 0)
   given Conversion[Long, VNum] = n => complex(n, 0)
   given Conversion[BigInt, VNum] = n => complex(n, 0)
+  given Conversion[Real, VNum] = n => complex(n, 0)
   given Conversion[Complex[Real], VNum] = new VNum(_)
   given Conversion[Boolean, VNum] =
     b => if b then 1 else 0 // scalafix:ok DisableSyntax.BooleanToVNum

--- a/shared/src/main/scala/VNum.scala
+++ b/shared/src/main/scala/VNum.scala
@@ -49,6 +49,7 @@ object VNum:
     val real = parts.lift(0).getOrElse("0")
     val imag = if s.endsWith("ı") then "1" else parts.lift(1).getOrElse("0")
 
+    // Apologies for not using val - I need to use the same variable twice
     var realNum: String = if real.last == '.' then real + "5" else real
     realNum = if realNum.startsWith(".") then "0" + realNum else realNum
     var imagNum: String = if imag.last == '.' then imag + "5" else imag

--- a/shared/src/test/scala/InterpreterTests.scala
+++ b/shared/src/test/scala/InterpreterTests.scala
@@ -1,6 +1,7 @@
 package vyxal
 
 import org.scalatest.funsuite.AnyFunSuite
+import spire.math.{Complex, Real}
 
 class InterpreterTests extends AnyFunSuite:
   test("Can the interpreter make lists?") {
@@ -152,13 +153,31 @@ class InterpreterTests extends AnyFunSuite:
   test("References to variables in other contexts") {
     val ctx1 = Context()
     ctx1.setVar("x", 5)
-    Interpreter.execute(AST.Lambda(1, Nil, AST.AugmentVar("x", AST.Command("+"))))(using ctx1)
+    Interpreter.execute(
+      AST.Lambda(1, Nil, AST.AugmentVar("x", AST.Command("+")))
+    )(using ctx1)
     val ctx2 = Context()
     ctx2.setVar("x", "foo")
     ctx2.push(1)
     ctx2.push(ctx1.pop())
     Interpreter.execute(AST.ExecuteFn)(using ctx2)
     assertResult((VNum(6), "foo"))((ctx1.getVar("x"), ctx2.getVar("x")))
+  }
+
+  test("Numeric literals are handled correctly") {
+    assertResult(VNum(0))(VNum.from("0"))
+    assertResult(VNum(1))(VNum.from("1"))
+    assertResult(VNum(Real("6.9")))(VNum.from("6.9"))
+    assertResult(VNum(Real("0.9")))(VNum.from(".9"))
+    assertResult(VNum(Real("0.9")))(VNum.from("0.9"))
+    assertResult(VNum(Real("0.5")))(VNum.from("."))
+    assertResult(VNum(Real("0.5")))(VNum.from("0."))
+    assertResult(VNum(Real("5.5")))(VNum.from("5."))
+    assertResult(VNum.complex(0, 1))(VNum.from("ı"))
+    assertResult(VNum.complex(0, 1))(VNum.from("0ı"))
+    assertResult(VNum.complex(0.5, 1))(VNum.from("0.ı"))
+    assertResult(VNum.complex(0.5, 0.5))(VNum.from(".ı."))
+    assertResult(VNum.complex(69, 420))(VNum.from("69ı420"))
   }
 
 end InterpreterTests

--- a/shared/src/test/scala/LexerTests.scala
+++ b/shared/src/test/scala/LexerTests.scala
@@ -1,13 +1,20 @@
 package vyxal
 
 import org.scalatest.funsuite.AnyFunSuite
-
 import VyxalToken.*
 
-class LexerTests extends AnyFunSuite {
+class LexerTests extends AnyFunSuite:
   test("Does the lexer recognise numbers?") {
     assert(Lexer("123") == Right(List(Number("123"))))
     assert(Lexer("6.") == Right(List(Number("6."))))
+    assert(Lexer("3.4ı1.2") == Right(List(Number("3.4ı1.2"))))
+    assert(Lexer("3.4ı1.") == Right(List(Number("3.4ı1."))))
+    assert(Lexer("3.4ı.2") == Right(List(Number("3.4ı.2"))))
+    assert(Lexer("3.4ı.") == Right(List(Number("3.4ı."))))
+    assert(Lexer(".ı.") == Right(List(Number(".ı."))))
+    assert(Lexer("3.4ı") == Right(List(Number("3.4ı"))))
+    assert(Lexer(".4") == Right(List(Number(".4"))))
+    assert(Lexer(".") == Right(List(Number("."))))
   }
 
   test("Does the lexer recognise strings?") {
@@ -73,7 +80,13 @@ class LexerTests extends AnyFunSuite {
     )
   }
 
-  test("Does the lexer recognise variable digraphs?"){assert(Lexer("3 #$my_var +") === Right(List(Number("3"), GetVar("my_var"), Command("+"))))
+  test("Does the lexer recognise variable digraphs?") {
+    assert(
+      Lexer("3 #$my_var +") === Right(
+        List(Number("3"), GetVar("my_var"), Command("+"))
+      )
+    )
 
-assert(Lexer("42 #=answer") === Right(List(Number("42"), SetVar("answer"))))}
-}
+    assert(Lexer("42 #=answer") === Right(List(Number("42"), SetVar("answer"))))
+  }
+end LexerTests


### PR DESCRIPTION
Before decimals just didn't work, because of a call to `.toInt`.

Now, all sorts of hanging literals are handled.