### PR TITLE
Add desc of ṁ for num in yml

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1217,6 +1217,7 @@ Average of a list - sum / length
 ### Overloads
 
 - str a: `palindromise(a) (a + a[:-1:-1])`
+- num a: `random.randint(0, a)`
 - lst a: `mean(a)`
 -------------------------------
 ## `` ṅ `` (Join By Nothing)

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1047,6 +1047,7 @@ z (Zip-self)
 - Average of a list - sum / length
 
     str a: palindromise(a) (a + a[:-1:-1])
+    num a: random.randint(0, a)
     lst a: mean(a)
 -------------------------------
 ṅ (Join By Nothing)

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1804,6 +1804,7 @@
   arity: 1
   overloads:
     str: palindromise(a) (a + a[:-1:-1])
+    num: random.randint(0, a)
     lst: mean(a)
   vectorise: false
   tests:

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2279,7 +2279,7 @@ var codepage_descriptions =
     {
       "name": "Mean",
       "description": "Average of a list - sum / length",
-      "overloads": "str -> palindromise(a) (a + a[:-1:-1])\nlst -> mean(a)",
+      "overloads": "str -> palindromise(a) (a + a[:-1:-1])\nnum -> random.randint(0, a)\nlst -> mean(a)",
       "token": "\u1e41"
     },
     {


### PR DESCRIPTION
Pointed out by 97.100.97.109 [in chat](https://chat.stackexchange.com/transcript/message/62873860#62873860). `ṁ`'s num overload isn't documented in elements.yaml (but the docstring does have it).