### PR TITLE
Make `o` use all integers

### DIFF
--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -875,8 +875,8 @@ Remove instances of b in a
 
 ### Overloads
 
-- num a, fun b: `first a positive integers where b is truthy`
-- fun a, num b: `first b positive integers where a is truthy`
+- num a, fun b: `first a integers where b is truthy (0, 1, -1, ...)`
+- fun a, num b: `first b integers where a is truthy`
 - any a, any b: `a.replace(b,"")`
 -------------------------------
 ## `` p `` (Prepend)
@@ -1237,7 +1237,7 @@ Slice from an index to the end
 
 ### Overloads
 
-- fun a, num b: `first b integers for which a(x) is truthy (0, 1, -1, ...)`
+- fun a, num b: `first b positive integers for which a(x) is truthy`
 - any a, num b: `a[b:] (slice from b to the end)`
 - str a, str b: `vertically merge a and b`
 -------------------------------

--- a/documents/knowledge/elements.md
+++ b/documents/knowledge/elements.md
@@ -1237,7 +1237,7 @@ Slice from an index to the end
 
 ### Overloads
 
-- fun a, num b: `first b integers for which a(x) is truthy`
+- fun a, num b: `first b integers for which a(x) is truthy (0, 1, -1, ...)`
 - any a, num b: `a[b:] (slice from b to the end)`
 - str a, str b: `vertically merge a and b`
 -------------------------------

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -762,8 +762,8 @@ o (Remove)
 
 - Remove instances of b in a
 
-    num a, fun b: first a positive integers where b is truthy
-    fun a, num b: first b positive integers where a is truthy
+    num a, fun b: first a integers where b is truthy (0, 1, -1, ...)
+    fun a, num b: first b integers where a is truthy
     any a, any b: a.replace(b,"")
 -------------------------------
 p (Prepend)
@@ -1063,7 +1063,7 @@ z (Zip-self)
 
 - Slice from an index to the end
 
-    fun a, num b: first b integers for which a(x) is truthy (0, 1, -1, ...)
+    fun a, num b: first b positive integers for which a(x) is truthy
     any a, num b: a[b:] (slice from b to the end)
     str a, str b: vertically merge a and b
 -------------------------------

--- a/documents/knowledge/elements.txt
+++ b/documents/knowledge/elements.txt
@@ -1063,7 +1063,7 @@ z (Zip-self)
 
 - Slice from an index to the end
 
-    fun a, num b: first b integers for which a(x) is truthy
+    fun a, num b: first b integers for which a(x) is truthy (0, 1, -1, ...)
     any a, num b: a[b:] (slice from b to the end)
     str a, str b: vertically merge a and b
 -------------------------------

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1840,7 +1840,7 @@
   description: Slice from an index to the end
   arity: 2
   overloads:
-    fun-num: first b integers for which a(x) is truthy
+    fun-num: first b integers for which a(x) is truthy (0, 1, -1, ...)
     any-num: a[b:] (slice from b to the end)
     str-str: vertically merge a and b
   vectorise: false

--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -1296,8 +1296,8 @@
   description: Remove instances of b in a
   arity: 2
   overloads:
-    num-fun: first a positive integers where b is truthy
-    fun-num: first b positive integers where a is truthy
+    num-fun: first a integers where b is truthy (0, 1, -1, ...)
+    fun-num: first b integers where a is truthy
     any-any: a.replace(b,"")
   vectorise: false
   tests:
@@ -1840,7 +1840,7 @@
   description: Slice from an index to the end
   arity: 2
   overloads:
-    fun-num: first b integers for which a(x) is truthy (0, 1, -1, ...)
+    fun-num: first b positive integers for which a(x) is truthy
     any-num: a[b:] (slice from b to the end)
     str-str: vertically merge a and b
   vectorise: false

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -1695,7 +1695,7 @@ var codepage_descriptions =
     {
       "name": "Remove",
       "description": "Remove instances of b in a",
-      "overloads": "num, fun -> first a positive integers where b is truthy\nfun, num -> first b positive integers where a is truthy\nany, any -> a.replace(b,\"\")",
+      "overloads": "num, fun -> first a integers where b is truthy (0, 1, -1, ...)\nfun, num -> first b integers where a is truthy\nany, any -> a.replace(b,\"\")",
       "token": "o"
     },
     {
@@ -2324,7 +2324,7 @@ var codepage_descriptions =
     {
       "name": "Slice",
       "description": "Slice from an index to the end",
-      "overloads": "fun, num -> first b integers for which a(x) is truthy (0, 1, -1, ...)\nany, num -> a[b:] (slice from b to the end)\nstr, str -> vertically merge a and b",
+      "overloads": "fun, num -> first b positive integers for which a(x) is truthy\nany, num -> a[b:] (slice from b to the end)\nstr, str -> vertically merge a and b",
       "token": "\u022f"
     },
     {

--- a/static/parsed_yaml.js
+++ b/static/parsed_yaml.js
@@ -2324,7 +2324,7 @@ var codepage_descriptions =
     {
       "name": "Slice",
       "description": "Slice from an index to the end",
-      "overloads": "fun, num -> first b integers for which a(x) is truthy\nany, num -> a[b:] (slice from b to the end)\nstr, str -> vertically merge a and b",
+      "overloads": "fun, num -> first b integers for which a(x) is truthy (0, 1, -1, ...)\nany, num -> a[b:] (slice from b to the end)\nstr, str -> vertically merge a and b",
       "token": "\u022f"
     },
     {

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -282,7 +282,7 @@ def test_slice_to_end_infinite_lists():
 
 
 def test_first_integers():
-    stack = run_vyxal("λ1; 5 ȯ")
+    stack = run_vyxal("λ1; 5 o")
     # Lambda basically accepts everything
     assert stack[-1][:5] == [0, 1, -1, 2, -2]
 

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -281,6 +281,12 @@ def test_slice_to_end_infinite_lists():
     assert stack[-1][:5] == [21, 22, 23, 24, 25]
 
 
+def test_first_integers():
+    stack = run_vyxal("λ1; 5 ȯ")
+    # Lambda basically accepts everything
+    assert stack[-1][:5] == [0, 1, -1, 2, -2]
+
+
 def test_strip_infinite_lists():
     """Ensure that P only strips from the start for infinite lists"""
     stack = run_vyxal("⁽›1Ḟ 1 9 r P")

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5126,7 +5126,7 @@ def remove(lhs, rhs, ctx):
     ts = vy_type(lhs)
     if set(vy_type(lhs, rhs)) == {types.FunctionType, NUMBER_TYPE}:
         func, count = (rhs, lhs) if ts is types.FunctionType else (lhs, rhs)
-        return vy_filter(func, infinite_positives(None, ctx), ctx)[:count]
+        return vy_filter(func, infinite_all_integers(None, ctx), ctx)[:count]
     if ts == str:
         return replace(lhs, rhs, "", ctx)
     elif ts == LazyList:
@@ -5646,7 +5646,7 @@ def slice_from(lhs, rhs, ctx):
     ts = vy_type(lhs, rhs, simple=True)
     if types.FunctionType in ts:
         func, count = (lhs, rhs) if ts[0] is types.FunctionType else (rhs, lhs)
-        return vy_filter(func, infinite_all_integers(None, ctx), ctx)[:count]
+        return vy_filter(func, infinite_positives(None, ctx), ctx)[:count]
     else:
         return {
             (str, str): lambda: lhs + "\n" + rhs,

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5125,7 +5125,7 @@ def remove(lhs, rhs, ctx):
     lhs = iterable(lhs)
     ts = vy_type(lhs)
     if set(vy_type(lhs, rhs)) == {types.FunctionType, NUMBER_TYPE}:
-        func, count = (rhs, lhs) if ts is types.FunctionType else (lhs, rhs)
+        func, count = (lhs, rhs) if ts is types.FunctionType else (rhs, lhs)
         return vy_filter(func, infinite_all_integers(None, ctx), ctx)[:count]
     if ts == str:
         return replace(lhs, rhs, "", ctx)

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5645,9 +5645,7 @@ def slice_from(lhs, rhs, ctx):
     """
     ts = vy_type(lhs, rhs, simple=True)
     if types.FunctionType in ts:
-        func, count = (
-            (lhs, rhs) if ts[0] is types.FunctionType else (rhs, lhs)
-        )
+        func, count = (lhs, rhs) if ts[0] is types.FunctionType else (rhs, lhs)
         return vy_filter(func, infinite_all_integers(None, ctx), ctx)[:count]
     else:
         return {

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5125,19 +5125,8 @@ def remove(lhs, rhs, ctx):
     lhs = iterable(lhs)
     ts = vy_type(lhs)
     if set(vy_type(lhs, rhs)) == {types.FunctionType, NUMBER_TYPE}:
-        lhs, rhs = (rhs, lhs) if ts is types.FunctionType else (lhs, rhs)
-
-        @lazylist
-        def gen():
-            value = 1
-            found = 0
-            while found != rhs:
-                if lhs(value):
-                    yield value
-                    found += 1
-                value += 1
-
-        return gen()
+        func, count = (rhs, lhs) if ts is types.FunctionType else (lhs, rhs)
+        return vy_filter(func, infinite_positives(None, ctx), ctx)[:count]
     if ts == str:
         return replace(lhs, rhs, "", ctx)
     elif ts == LazyList:
@@ -5656,25 +5645,10 @@ def slice_from(lhs, rhs, ctx):
     """
     ts = vy_type(lhs, rhs, simple=True)
     if types.FunctionType in ts:
-        function, count = (
+        func, count = (
             (lhs, rhs) if ts[0] is types.FunctionType else (rhs, lhs)
         )
-
-        @lazylist
-        def gen():
-            found = 0
-            item = 1
-            while True:
-                if found == count:
-                    break
-                res = safe_apply(function, item, ctx=ctx)
-                if boolify(res, ctx=ctx):
-                    found += 1
-                    yield item
-                item += 1
-
-        return gen()
-
+        return vy_filter(func, infinite_all_integers(None, ctx), ctx)[:count]
     else:
         return {
             (str, str): lambda: lhs + "\n" + rhs,


### PR DESCRIPTION
<s>What the linked issue suggests. Since `ȯ`'s description doesn't say just positive integers, it's been changed to be all integers now to avoid duplicating the functionality of `o`.</s> Other way round now, `o` will be all integers, `ȯ` will be positive integers.