### PR TITLE
Scala Native support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,13 +16,13 @@ Test / testOptions += Tests.Argument("-oNCXEHLOPQRM")
 
 lazy val root = project
   .in(file("."))
-  .aggregate(vyxal.js, vyxal.jvm)
+  .aggregate(vyxal.js, vyxal.jvm, vyxal.native)
   .settings(
     publish := {},
     publishLocal := {}
   )
 
-lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
+lazy val vyxal = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
     // Shared settings
@@ -80,4 +80,11 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform)
     // Where the compiled JS is output
     Compile / fastOptJS / artifactPath := baseDirectory.value / "lib" / s"scalajs-$vyxalVersion.js",
     Compile / fullOptJS / artifactPath := baseDirectory.value / "lib" / s"scalajs-$vyxalVersion.js"
+  )
+  .nativeSettings(
+    // Scala Native-specific settings
+    libraryDependencies ++= Seq(
+      // For command line parsing
+      "com.github.scopt" %%% "scopt" % "4.1.0"
+    )
   )

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,7 @@ import mill.scalanativelib._
 import mill.scalanativelib.api._
 
 /** Shared settings for all modules */
-trait VyxalModule extends SbtModule {
+trait VyxalModule extends ScalaModule {
   def platform: String
 
   def scalaVersion = "3.2.1"
@@ -49,7 +49,7 @@ trait VyxalModule extends SbtModule {
 }
 
 /** Shared and JVM-specific code */
-object jvm extends VyxalModule {
+object jvm extends ScalaModule with VyxalModule {
   def platform = "jvm"
 
   def ivyDeps = T { super.ivyDeps() ++ Seq(ivy"com.github.scopt::scopt:4.1.0") }
@@ -58,7 +58,7 @@ object jvm extends VyxalModule {
 }
 
 /** Shared and JS-specific code */
-object js extends VyxalModule with ScalaJSModule {
+object js extends ScalaJSModule with VyxalModule {
   def platform = "js"
   def scalaJSVersion = "1.12.0"
   def moduleKind = T { ModuleKind.NoModule }
@@ -67,11 +67,16 @@ object js extends VyxalModule with ScalaJSModule {
 }
 
 /** Shared and native-specific code */
-object native extends VyxalModule with ScalaNativeModule {
+object native extends ScalaNativeModule with VyxalModule {
   def platform = "native"
   def scalaNativeVersion = "0.4.9"
 
   def ivyDeps = T { super.ivyDeps() ++ Seq(ivy"com.github.scopt::scopt::4.1.0") }
 
-  object test extends VyxalTestModule
+  def releaseMode = ReleaseMode.ReleaseFast
+  def nativeLTO = LTO.Thin
+
+  object test extends ScalaNativeModule with VyxalTestModule {
+    def scalaNativeVersion = native.this.scalaNativeVersion
+  }
 }

--- a/build.sc
+++ b/build.sc
@@ -49,7 +49,7 @@ trait VyxalModule extends ScalaModule {
 }
 
 /** Shared and JVM-specific code */
-object jvm extends ScalaModule with VyxalModule {
+object jvm extends VyxalModule {
   def platform = "jvm"
 
   def ivyDeps = T { super.ivyDeps() ++ Seq(ivy"com.github.scopt::scopt:4.1.0") }

--- a/build.sc
+++ b/build.sc
@@ -2,6 +2,8 @@ import mill._
 import mill.scalajslib._
 import mill.scalajslib.api._
 import mill.scalalib._
+import mill.scalanativelib._
+import mill.scalanativelib.api._
 
 /** Shared settings for all modules */
 trait VyxalModule extends SbtModule {
@@ -51,6 +53,8 @@ object jvm extends VyxalModule {
   def platform = "jvm"
 
   def ivyDeps = T { super.ivyDeps() ++ Seq(ivy"com.github.scopt::scopt:4.1.0") }
+
+  object test extends VyxalTestModule
 }
 
 /** Shared and JS-specific code */
@@ -58,6 +62,16 @@ object js extends VyxalModule with ScalaJSModule {
   def platform = "js"
   def scalaJSVersion = "1.12.0"
   def moduleKind = T { ModuleKind.NoModule }
+
+  object test extends VyxalTestModule
+}
+
+/** Shared and native-specific code */
+object native extends VyxalModule with ScalaNativeModule {
+  def platform = "native"
+  def scalaNativeVersion = "0.4.9"
+
+  def ivyDeps = T { super.ivyDeps() ++ Seq(ivy"com.github.scopt::scopt::4.1.0") }
 
   object test extends VyxalTestModule
 }

--- a/native/src/main/scala/Main.scala
+++ b/native/src/main/scala/Main.scala
@@ -1,0 +1,260 @@
+package vyxal
+
+import vyxal.impls.{Element, Elements}
+
+import java.io.File
+import scopt.OParser
+
+/** Configuration for the command line argument parser
+  *
+  * @param file
+  *   File to read code from (optional)
+  * @param code
+  *   Code to run (optional)
+  * @param inputs
+  *   Inputs to program (optional)
+  * @param printDocs
+  *   Whether to print descriptions of all the elements
+  * @param settings
+  *   Extra settings passed on to the Context
+  */
+case class CLIConfig(
+    file: Option[File] = None,
+    code: Option[String] = None,
+    inputs: List[String] = List.empty,
+    printDocs: Boolean = false,
+    printHelp: Boolean = false,
+    settings: Settings = Settings()
+)
+
+object Main:
+  def main(args: Array[String]): Unit =
+    OParser.parse(parser, args, CLIConfig()) match
+      case Some(config) =>
+        given Context = Context(
+          config.inputs.reverse.map(Parser.parseInput)
+        )
+
+        if config.printHelp then
+          println(OParser.usage(parser))
+          return
+
+        if config.printDocs then
+          printDocs()
+          return
+
+        config.file.foreach { file =>
+          val source = io.Source.fromFile(config.file.get)
+          try
+            Interpreter.execute(source.mkString)
+          finally
+            source.close()
+        }
+
+        config.code.foreach { code =>
+          Interpreter.execute(code)
+        }
+
+        if config.file.nonEmpty || config.code.nonEmpty then return
+        else Repl.startRepl()
+      case None => ???
+    end match
+  end main
+
+  private def printDocs(): Unit =
+    Elements.elements.values.toSeq
+      .sortBy { elem =>
+        // Have to use tuple in case of digraphs
+        (
+          vyxal.CODEPAGE.indexOf(elem.symbol.charAt(0)),
+          vyxal.CODEPAGE.indexOf(elem.symbol.substring(1))
+        )
+      }
+      .foreach {
+        case Element(
+              symbol,
+              name,
+              keywords,
+              arity,
+              vectorises,
+              overloads,
+              impl
+            ) =>
+          print(
+            s"$symbol ($name) (${if vectorises then "" else "non-"}vectorising)\n"
+          )
+          overloads.foreach { overload =>
+            println(s"- $overload")
+          }
+          println("---------------------")
+      }
+
+  private val builder = OParser.builder[CLIConfig]
+
+  private val parser =
+    import builder.*
+
+    def flag(short: Char, name: String, text: String) =
+      opt[Unit](short, name)
+        .action((_, cfg) => cfg.copy(settings = cfg.settings.withFlag(short)))
+        .text(text)
+        .optional()
+
+    // todo come up with better names for the flags
+    OParser.sequence(
+      programName("vyxal"),
+      head("vyxal", "3.1.1"),
+      opt[Unit]('h', "help")
+        .action((_, cfg) => cfg.copy(printHelp = true))
+        .text("Print this help message and exit")
+        .optional(),
+      opt[File]('f', "file")
+        .action((file, cfg) => cfg.copy(file = Some(file)))
+        .text("The file to read the program from")
+        .optional(),
+      opt[String]('c', "code")
+        .action((code, cfg) => cfg.copy(code = Some(code)))
+        .text("Code to execute directly")
+        .optional(),
+      opt[Unit]('d', "docs")
+        .action((_, cfg) => cfg.copy(printDocs = true))
+        .text("Print documentation for elements and exit")
+        .optional(),
+      arg[String]("<input>...")
+        .unbounded()
+        .optional()
+        .action((input, cfg) => cfg.copy(inputs = cfg.inputs :+ input))
+        .text("Input to the program"),
+      flag('H', "preset-100", "Preset stack to 100"),
+      flag(
+        'j',
+        "print-join-newlines",
+        "Print top of stack joined by newlines on end of execution"
+      ),
+      flag(
+        'L',
+        "print-join-newlines-vert",
+        "Print top of stack joined by newlines (Vertically) on end of execution"
+      ),
+      flag(
+        's',
+        "print-sum",
+        "Sum/concatenate top of stack on end of execution"
+      ),
+      flag(
+        'M',
+        "range-start-0",
+        "Make implicit range generation and while loop counter start at 0 instead of 1"
+      ),
+      flag(
+        'm',
+        "range-end-excl",
+        "Make implicit range generation end at n-1 instead of n"
+      ),
+      flag(
+        'Ṁ',
+        "range-programmery",
+        "Equivalent to having both m and M flags"
+      ),
+      flag('v', "vyxal-enc", "Use Vyxal encoding for input file"),
+      // todo output ASTs instead?
+      flag('c', "output-compiled", "Output compiled code (for debugging)"),
+      flag(
+        'a',
+        "newline-sep-as-list",
+        "Treat newline seperated values as a list"
+      ),
+      flag(
+        'd',
+        "print-deep-sum",
+        "Print deep sum of top of stack on end of execution"
+      ),
+      flag(
+        'r',
+        "reverse-ops",
+        "Makes all operations happen with reverse arguments"
+      ),
+      flag(
+        'S',
+        "print-join-spaces",
+        "Print top of stack joined by spaces on end of execution"
+      ),
+      flag(
+        'C',
+        "print-centre-join-newlines",
+        "Centre the output and join on newlines on end of execution"
+      ),
+      flag('O', "disable-implicit-output", "Disable implicit output"),
+      flag('o', "force-implicit-output", "Force implicit output"),
+      flag(
+        'l',
+        "print-length",
+        "Print length of top of stack on end of execution"
+      ),
+      flag(
+        'G',
+        "print-max",
+        "Print the maximum item of the top of stack on end of execution"
+      ),
+      flag(
+        'g',
+        "print-max",
+        "Print the minimum item of the top of the stack on end of execution"
+      ),
+      flag('W', "print-all", "Print the entire stack on end of execution"),
+      flag('Ṡ', "inputs-as-strs", "Treat all inputs as strings"),
+      flag(
+        'R',
+        "numbers-as-ranges",
+        "Treat numbers as ranges if ever used as an iterable"
+      ),
+      flag(
+        'D',
+        "no-decompress-str",
+        "Treat all strings as raw strings (don't decompress strings)"
+      ),
+      flag(
+        'U',
+        "strings-utf8",
+        "Treat all strings as UTF-8 byte sequences (also don't decompress strings)"
+      ),
+      flag('Ṫ', "print-sum-all", "Print the sum of the entire stack"),
+      flag(
+        'ṡ',
+        "print-all-join-spaces",
+        "Print the entire stack, joined on spaces"
+      ),
+      flag(
+        'Z',
+        "zip-tetrad",
+        "With four argument vectorization where all arguments are lists, use zip(zip(a, b), zip(c, d)) instead of zip(a, b, c, d)"
+      ),
+      flag(
+        'J',
+        "print-all-join-newlines",
+        "Print the entire stack, separated by newlines"
+      ),
+      flag('t', "vect-boolify", "Vectorise boolify on Lists"),
+      flag(
+        'P',
+        "print-lists-python",
+        "Print lists as their python representation"
+      ),
+      flag('ḋ', "print-rat-decimal", "Print rationals in their decimal form"),
+      flag('V', "var-single-char", "Variables are one character long"),
+      flag(
+        '?',
+        "empty-as-0",
+        "If there is empty input, treat it as 0 instead of empty string."
+      ),
+      flag('2', "arity-2", "Make the default arity of lambdas 2"),
+      flag('3', "arity-3", "Make the default arity of lambdas 3"),
+      flag('A', "run-tests", "Run test cases on all inputs"),
+      flag(
+        '…',
+        "limit-output",
+        "Limit list output to the first 100 items of that list"
+      )
+    )
+  end parser
+end Main

--- a/native/src/main/scala/Repl.scala
+++ b/native/src/main/scala/Repl.scala
@@ -1,0 +1,11 @@
+package vyxal
+
+import scala.io.StdIn
+
+object Repl:
+  def startRepl()(using ctx: Context): Unit =
+    while true do
+      print("> ")
+
+      val code = StdIn.readLine()
+      Interpreter.execute(code)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,8 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.10")
 // For making an uber JAR
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
 // For auto-formatting

--- a/shared/src/main/scala/Interpreter.scala
+++ b/shared/src/main/scala/Interpreter.scala
@@ -15,8 +15,7 @@ object Interpreter:
         if !ctx.isStackEmpty && ctx.settings.endPrintMode == EndPrintMode.Default
         then println(ctx.peek)
       case Left(error) =>
-        println(s"Error while executing $code: $error")
-        ???
+        throw new Error(s"Error while executing $code: $error")
 
   def execute(ast: AST)(using ctx: Context): Unit =
     if ctx.settings.logLevel == LogLevel.Debug then

--- a/shared/src/main/scala/Lexer.scala
+++ b/shared/src/main/scala/Lexer.scala
@@ -70,7 +70,7 @@ object Lexer extends RegexParsers:
       Number(value)
     }
 
-  def string: Parser[VyxalToken] = raw"""("(?:[^"„”“\\]|\.)*["„”“])""".r ^^ {
+  def string: Parser[VyxalToken] = raw"""("(?:[^"„”“\\]|\\.)*["„”“])""".r ^^ {
     value =>
       // If the last character of each token is ", then it's a normal string
       // If the last character of each token is „, then it's a compressed string

--- a/shared/src/main/scala/Lexer.scala
+++ b/shared/src/main/scala/Lexer.scala
@@ -1,5 +1,6 @@
 package vyxal
 
+import java.util.regex.Pattern
 import scala.util.matching.Regex
 import scala.util.parsing.combinator.*
 import VyxalToken.*
@@ -49,9 +50,9 @@ enum StructureType(val open: String):
   case LambdaSort extends StructureType("µ")
 
 val CODEPAGE = """ᵃᵇᶜᵈᵉᶠᶢᴴᶤᶨᵏᶪᵐⁿᵒᵖᴿᶳᵗᵘᵛᵂᵡᵞᶻᶴ′″‴⁴ᵜ !"#$%&'()*+,-./0123456789:;
-<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~¦ȦḂĊḊĖḞĠḢİĿṀṄ
+<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~¦ȦḂĊḊĖḞĠḢİĿṀṄ
 ȮṖṘṠṪẆẊικȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẋƒΘΦ§ẠḄḌḤỊḶṂṆỌṚṢṬ…≤≥≠₌⁺⁻⁾√∑«»⌐∴∵⊻₀₁₂₃₄₅₆₇₈₉λƛΩ₳µ∆øÞ½ʀɾ¯
-×÷£¥←↑→↓±‡†Π¬∧∨⁰¹²³¤¨∥∦ı„”ð€“¶ᶿᶲ•≈¿ꜝ"""
+×÷£¥←↑→↓±‡†Π¬∧∨⁰¹²³¤¨∥∦ı„”ð€“¶ᶿᶲ•≈¿ꜝ""".replaceAll("\n", "")
 
 val MONADIC_MODIFIERS = "ᵃᵇᶜᵈᵉᶠᶢᴴᶤᶨᵏᶪᵐⁿᵒᵖᴿᶳᵘᵛᵂᵡᵞᶻ¿′/\\~v@`ꜝ"
 val DYADIC_MODIFIERS = "″∥∦"
@@ -63,12 +64,13 @@ object Lexer extends RegexParsers:
   override def skipWhitespace = true
   override val whiteSpace: Regex = "[ \t\r\f]+".r
 
+  private def decimalRegex = raw"((0|[1-9][0-9]*)?\.[0-9]*|0|[1-9][0-9]*)"
   def number: Parser[VyxalToken] =
-    """(0(?=[^.ı])|\d*\.\d*(ı(\d*\.\d*|\d+)?)?|\.|ı|\d+)""".r ^^ { value =>
+    raw"($decimalRegex?ı$decimalRegex?)|$decimalRegex".r ^^ { value =>
       Number(value)
     }
 
-  def string: Parser[VyxalToken] = """("(?:[^"„”“\\\\]|\\.)*["„”“])""".r ^^ {
+  def string: Parser[VyxalToken] = raw"""("(?:[^"„”“\\]|\.)*["„”“])""".r ^^ {
     value =>
       // If the last character of each token is ", then it's a normal string
       // If the last character of each token is „, then it's a compressed string
@@ -117,7 +119,10 @@ object Lexer extends RegexParsers:
       else SugarTrigraph(value)
     }
 
-  def command: Parser[VyxalToken] = s"[$CODEPAGE]".r ^^ { value =>
+  private val commandRegex = CODEPAGE
+    .replaceAll(raw"[|\[\](){}]", "")
+    .replace("^", "\\^")
+  def command: Parser[VyxalToken] = s"[$commandRegex]".r ^^ { value =>
     Command(value)
   }
 


### PR DESCRIPTION
This branch is for eventually creating Vyxal executables directly using Scala Native. There's also GraalVM, which we should check out too. Executables made by Scala Native will likely be smaller, since they don't contain all the Java stuff that GraalVM has. Scala Native will also be able to optimize more, since it's aware of the original Scala code, while GraalVM works on bytecode. However, the size and performance difference probably won't be big enough to be noticeable, and GraalVM has been around longer than Scala Native and works on JARs, so we may just want to go with that.