### PR TITLE
Relative path for worker.js

### DIFF
--- a/pages/main.js
+++ b/pages/main.js
@@ -730,7 +730,7 @@ window.addEventListener("DOMContentLoaded", e => {
             location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
         }
         let runButton = $('run_button');
-        worker = new Worker('/worker.js');
+        worker = new Worker('./worker.js');
         worker.onmessage = function (e) {
             if (e.data.session != sessioncode) { return; }
             if (e.data.command == "done") { runButton.innerHTML = '<i class="fas fa-play-circle"></i>'; }


### PR DESCRIPTION
It was using `/worker.js` before, which tried to get it from vyxal.github.io/worker.js. Caught by [lyxal](https://chat.stackexchange.com/transcript/message/62961275#62961275)+[emanresu](https://chat.stackexchange.com/transcript/message/62961367#62961367)