### PR TITLE
Replace `¦` with newlines when decompressing strings

### DIFF
--- a/shared/src/main/scala/StringHelpers.scala
+++ b/shared/src/main/scala/StringHelpers.scala
@@ -172,7 +172,7 @@ object StringHelpers:
       end if
     end while
 
-    decompressed.mkString
+    decompressed.mkString.replace("¦", "\n")
   end decompress
 
   def swapcase(s: String): String =


### PR DESCRIPTION
Closes #1659 

The problem was Jelly being all weird again.