### PR TITLE
Make transpose not return a generator

### DIFF
--- a/documents/knowledge/elements.yaml
+++ b/documents/knowledge/elements.yaml
@@ -2880,6 +2880,7 @@
     - "[1234] : [[1, 2, 3, 4]]"
     - '[["abc", "def", "ghi"]] : ["adg", "beh", "cfi"]'
     - '[["abcde", "fgh"]] : ["af", "bg", "ch", "d", "e"]'
+    - '[[123, "abc"]] : [[1, "a"], [2, "b"], [3, "c"]]'
 
 - element: "⊍"
   name: Symmetric Set difference

--- a/vyxal/helpers.py
+++ b/vyxal/helpers.py
@@ -1251,11 +1251,11 @@ def transpose(
             if type(matrix[r]) is str:
                 yield "".join(this_row)
             else:
-                yield this_row
+                yield LazyList(this_row)
+            r += 1
 
         else:
             break
-        r += 1
 
 
 def uncompress(token: lexer.Token) -> Union[int, str]:


### PR DESCRIPTION
Closes #1694

Transpose was returning a generator directly without converting it to a `LazyList` first.