### PR TITLE
Make negative bit shifts not error

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -3508,7 +3508,7 @@ def left_bit_shift(lhs, rhs, ctx):
     """
     ts = vy_type(lhs, rhs)
     return {
-        (NUMBER_TYPE, NUMBER_TYPE): lambda: int(lhs) << int(rhs),
+        (NUMBER_TYPE, NUMBER_TYPE): lambda: int(lhs) << int(rhs) if rhs > 0 else int(lhs) >> int(rhs),
         (NUMBER_TYPE, str): lambda: rhs.ljust(lhs),
         (str, NUMBER_TYPE): lambda: lhs.ljust(rhs),
         (str, str): lambda: lhs.ljust(len(rhs)),
@@ -5417,7 +5417,7 @@ def right_bit_shift(lhs, rhs, ctx):
     """
     ts = vy_type(lhs, rhs)
     return {
-        (NUMBER_TYPE, NUMBER_TYPE): lambda: int(lhs) >> int(rhs),
+        (NUMBER_TYPE, NUMBER_TYPE): lambda: int(lhs) >> int(rhs) if rhs > 0 else int(lhs) << int(rhs),
         (str, NUMBER_TYPE): lambda: lhs.rjust(int(rhs), " "),
         (NUMBER_TYPE, str): lambda: rhs.rjust(int(lhs), " "),
         (str, str): lambda: lhs.rjust(len(rhs), " "),


### PR DESCRIPTION
When shifting a negative amount, it will now shift the other way

For example, [this](https://vyxal.pythonanywhere.com/#WyIiLCIiLCI1TuKGsyIsIiIsIjEwMCJd) should now give 3200 (`100 << 5`) rather than trying `100 >> -5` and failing.
