### PR TITLE
Make `øċ` return `u` for `-1`

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -4580,7 +4580,7 @@ def optimal_number_compress(lhs, ctx):
     (num) -> Semi-optimally compress a number
     """
     if lhs == -1:
-        return "u" # Otherwise it gives "1N"
+        return "u"  # Otherwise it gives "1N"
     if lhs < 0:
         return optimal_number_compress(-lhs, ctx) + "N"
     num_dict = {

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -4579,6 +4579,8 @@ def optimal_number_compress(lhs, ctx):
     """Element øċ
     (num) -> Semi-optimally compress a number
     """
+    if lhs == -1:
+        return "u" # Otherwise it gives "1N"
     if lhs < 0:
         return optimal_number_compress(-lhs, ctx) + "N"
     num_dict = {


### PR DESCRIPTION
[Before it was returning `1N`](https://vyxal.pythonanywhere.com/#WyIiLCIiLCLDuMSLIiwiIiwiLTEiXQ==), but there's a constant for `-1`.