### PR TITLE
Make `øR` work for negative numbers

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5590,7 +5590,9 @@ def roman_numeral(lhs, ctx):
         return result
     elif vy_type(lhs) is str:
         if lhs[:1] == "-":  # lhs[:1] is used to avoid the error if lhs is empty
-            return -roman_numeral(lhs[1:], ctx=ctx)  # If it starts with a minus sign, negate it
+            return -roman_numeral(
+                lhs[1:], ctx=ctx
+            )  # If it starts with a minus sign, negate it
         lhs = lhs.upper()
         result = 0
         for i, n in enumerate(big_nums):

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -5580,6 +5580,8 @@ def roman_numeral(lhs, ctx):
         "I",
     )
     if vy_type(lhs) is NUMBER_TYPE:
+        if lhs < 0:  # If it's less than 0, just prepend a minus sign
+            return "-" + roman_numeral(-lhs, ctx=ctx)
         result = ""
         for i, n in enumerate(ints):
             count = int(lhs / n)
@@ -5587,6 +5589,8 @@ def roman_numeral(lhs, ctx):
             lhs -= n * count
         return result
     elif vy_type(lhs) is str:
+        if lhs[:1] == "-":  # lhs[:1] is used to avoid the error if lhs is empty
+            return -roman_numeral(lhs[1:], ctx=ctx)  # If it starts with a minus sign, negate it
         lhs = lhs.upper()
         result = 0
         for i, n in enumerate(big_nums):


### PR DESCRIPTION
Before [it was just returning an empty string](https://vyxal.pythonanywhere.com/?v=1#WyIiLCIiLCLDuOG5mCIsIiIsIi0xMjMiXQ==) for negative numbers and [giving 0](https://vyxal.pythonanywhere.com/?v=1#WyIiLCIiLCLDuOG5mCIsIiIsIlwiLUNYWElJSVwiIl0=) for negative numerals.