### PR TITLE
Fix up a few calls to `max` with an empty list

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -528,10 +528,10 @@ def align_left(lhs, ctx):
     (str) -> left-aligned string
     (lst) -> left-align lines
     """
-    
+
     if not lhs:
         return []
-    
+
     ts = vy_type(lhs)
 
     if ts == str:
@@ -555,10 +555,10 @@ def align_right(lhs, ctx):
     (str) -> right-aligned string
     (lst) -> right-align lines
     """
-    
+
     if not lhs:
         return []
-    
+
     ts = vy_type(lhs)
 
     if ts == str:

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -528,6 +528,10 @@ def align_left(lhs, ctx):
     (str) -> left-aligned string
     (lst) -> left-align lines
     """
+    
+    if not lhs:
+        return []
+    
     ts = vy_type(lhs)
 
     if ts == str:
@@ -551,6 +555,10 @@ def align_right(lhs, ctx):
     (str) -> right-aligned string
     (lst) -> right-align lines
     """
+    
+    if not lhs:
+        return []
+    
     ts = vy_type(lhs)
 
     if ts == str:
@@ -2574,6 +2582,8 @@ def gridify(lhs, ctx):
     Gridify
     """
     lhs = [[vy_str(x, ctx=ctx) for x in x] for x in lhs]
+    if not lhs:
+        return ""
     width = max(max(map(len, x)) for x in lhs)
     return "\n".join(" ".join(x.rjust(width) for x in x) for x in lhs)
 
@@ -5087,6 +5097,8 @@ def prime_exponents_all(lhs, ctx):
     if ts == NUMBER_TYPE:
         # Get ALL primes less than lhs and then their exponents in the prime
         factors = sympy.ntheory.factor_.factorint(lhs)
+        if lhs < 2:
+            return []
         return [
             factors.get(x, 0)
             for x in sympy.primerange(


### PR DESCRIPTION
Basically there were a few places where `max` was being called with something which could have been an empty list (which would give an error).

Yes, I did test all of them on the online interpreter, and they were all erroring if you gave them empty lists. No, I'm not giving you all the links. No, I don't have time to do the same with `min` right now.