### PR TITLE
Use `vy_type` for checking against `NUMBER_TYPE`

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -445,7 +445,7 @@ else:
     "kṘ": process_element('"IVXLCDM"', 0),
     "k•": process_element('["qwertyuiop","asdfghjkl","zxcvbnm"]', 0),
     "¨w": (
-        "lhs = pop(stack, 1, ctx); isinstance(lhs, NUMBER_TYPE) and time.sleep(lhs)",
+        "lhs = pop(stack, 1, ctx); vy_type(lhs) == NUMBER_TYPE and time.sleep(lhs)",
         1,
     ),
 }


### PR DESCRIPTION
`NUMBER_TYPE` is actually a string. `vy_type` returns `NUMBER_TYPE` for all floats, ints, and sympy types. `isinstance` doesn't know about `NUMBER_TYPE` at all.

<!-- Make sure you add any issues this PR closes so Vyxal Bot can label it appropriately! -->
