### PR TITLE
Fix `isinstance` inside wait function

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -445,7 +445,7 @@ else:
     "kṘ": process_element('"IVXLCDM"', 0),
     "k•": process_element('["qwertyuiop","asdfghjkl","zxcvbnm"]', 0),
     "¨w": (
-        "lhs = pop(stack, 1, ctx); isinstance(lhs, NUMBER_TYPE) and time.sleep(lhs)",
+        "lhs = pop(stack, 1, ctx); isinstance(lhs, int) and time.sleep(lhs)",
         1,
     ),
 }


### PR DESCRIPTION
`isinstance` can only take a type object (e.g. `int`) or a tuple of type objects (e.g. `(int,str)`). This will be fixed with this commit.
Might fix #1801.
<!-- Make sure you add any issues this PR closes so Vyxal Bot can label it appropriately! -->
