### PR TITLE
reorder base_27_alphabet letters to match frequency.

### DIFF
--- a/vyxal/encoding.py
+++ b/vyxal/encoding.py
@@ -47,4 +47,4 @@ for char in string.printable:
 codepage_number_compress = codepage.replace("»", "")
 codepage_string_compress = codepage.replace("«", "")
 
-base_27_alphabet = " abcdefghijklmnopqrstuvwxyz"
+base_27_alphabet = " etaoinshrdlcumwfgypbvkjxqz"


### PR DESCRIPTION
[See here for letter frequency source.](https://en.wikipedia.org/wiki/Letter_frequency#:~:text=According%20to%20Lewand%2C%20arranged%20from%20most%20to%20least%20common%20in%20appearance%2C%20the%20letters%20are%3A%20etaoinshrdlcumwfgypbvkjxqz.)

<!-- Make sure you add any issues this PR closes so Vyxal Bot can label it appropriately! -->
