### PR TITLE
Make `Ḣ` return an empty string when given an empty string

### DIFF
--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -2754,6 +2754,8 @@ def head_remove(lhs, ctx):
     if vy_type(lhs, simple=True) in (list, str):
         return lhs[1:] if lhs else []
     if lhs < 2:
+        if isinstance(lhs, str):
+            return ""
         return []
 
     return iterable(lhs, range, ctx=ctx)[1:]


### PR DESCRIPTION
<!-- Make sure you add any issues this PR closes so Vyxal Bot can label it appropriately! -->
