### PR TITLE
correct path to tests.yaml in docs

### DIFF
--- a/documentation/Tests.md
+++ b/documentation/Tests.md
@@ -37,7 +37,7 @@ all the arguments that you use with `testOnly` (e.g. `jvm.test.testQuiet "*YamlT
 
 ## Writing Tests
 
-Simple tests go in [tests.yaml](/shared/src/test/resources/tests.yaml). Below is
+Simple tests go in [tests.yaml](/shared/test/resources/tests.yaml). Below is
 a description of how they look.
 
 ```yaml


### PR DESCRIPTION
it was pointing to an old folder before, but we're using mill's project structure now