### PR TITLE
Use full LTO for MacOS builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,13 +22,16 @@ jobs:
         include:
           - os: ubuntu-latest
             exe-name: vyxal-linux
+            lto: thin
           - os: macos-latest
             exe-name: vyxal-macos
+            lto: full # Thin doesn't work on Apple silicon yet
           - os: windows-latest
             exe-name: vyxal-windows
+            lto: thin
     env:
       SCALANATIVE_MODE: release-full
-      SCALANATIVE_LTO: thin
+      SCALANATIVE_LTO: ${{ matrix.lto }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17


### PR DESCRIPTION
Lyxal found [this issue](https://github.com/scala-native/scala-native/issues/2779) saying thin LTO doesn't work on Apple silicon