### PR TITLE
refactor: Merge addElem and addVect

### DIFF
--- a/shared/src/vyxal/Elements.scala
+++ b/shared/src/vyxal/Elements.scala
@@ -37,11 +37,12 @@ object Elements:
       "a: str, b: num -> a + b",
       "a: str, b: str -> a + b"
     )(MiscHelpers.add),
-    addVect(
+    addPart(
       Dyad,
       "ȧ",
       "Absolute Difference | Apply to Neighbours",
       List("abs-diff", "apply-to-neighbours"),
+      true,
       "a: num, b: num -> |a - b|",
       "a: lst, b: fun -> apply b to each pair of neighbours in a [applies to windows of length 2]"
     ) {
@@ -51,22 +52,24 @@ object Elements:
       case (a: VFun, b: VList) =>
         VList.from(ListHelpers.overlaps(b, 2).map(x => a(x*)))
     },
-    addVect(
+    addPart(
       Monad,
       "Ȧ",
       "Absolute Value | Keep Alphabet Characters",
       List("abs", "absolute-value", "keep-alphabet"),
+      true,
       "a: num -> |a|",
       "a: str -> keep alphabet characters of a"
     ) {
       case a: VNum => a.vabs
       case a: String => a.filter(_.isLetter)
     },
-    addElem(
+    addPart(
       Monad,
       "A",
       "All Truthy | All() | Is Vowel?",
       List("all", "is-vowel?", "vowel?"),
+      false,
       "a: str -> is (a) a vowel? vectorises for strings len > 1",
       "a: list -> is (a) all truthy?"
     ) {
@@ -75,11 +78,12 @@ object Elements:
       case a: String => VList(a.map(StringHelpers.isVowel)*)
       case a: VList => a.forall(_.toBool)
     },
-    addElem(
+    addPart(
       Monad,
       "a",
       "Any Truthy | Any() | Is Uppercase?",
       List("any", "is-uppercase?", "is-upper?", "upper?"),
+      false,
       "a: str -> is (a) uppercase? vectorises for strings len > 1",
       "a: list -> is (a) any truthy?"
     ) {
@@ -88,20 +92,22 @@ object Elements:
       case a: String => VList(a.map(c => VNum(c.isUpper))*)
       case a: VList => a.exists(_.toBool)
     },
-    addElem(
+    addPart(
       Dyad,
       "&",
       "Append",
       List("append"),
+      false,
       "a: any, b: any -> list(a) ++ [b]"
     ) { case (a, b) =>
       VList.from(ListHelpers.makeIterable(a) :+ b)
     },
-    addVect(
+    addPart(
       Monad,
       "ḃ",
       "Bit | Parity | Last Half of String",
       List("bit", "parity", "str-last-half"),
+      true,
       "a: num -> parity of a (a % 2)",
       "a: str -> last half of a"
     ) {
@@ -147,11 +153,12 @@ object Elements:
       "a: str -> int(a, 2)",
       "a: lst -> int(a, 2), using list of digits"
     )(NumberHelpers.fromBinary),
-    addVect(
+    addPart(
       Monad,
       "b",
       "Convert To Binary",
       List("to-binary", "dec->bin", "decimal->bin"),
+      true,
       "a: num -> convert a to binary",
       "a: str -> bin(ord(x) for x in a)"
     ) {
@@ -161,20 +168,22 @@ object Elements:
           a.map(x => NumberHelpers.toBinary(StringHelpers.chrord(x.toString)))*
         )
     },
-    addElem(
+    addPart(
       Monad,
       "#C",
       "Compress String Using Dictionary",
       List("compress-dict", "dict-comp", "compress"),
+      false,
       "a: str -> compress a using the dictionary"
     ) { case a: String =>
       StringHelpers.compressDictionary(a)
     },
-    addElem(
+    addPart(
       Dyad,
       "c",
       "Contains",
       List("contains", "in"),
+      false,
       "a: any, b: lst -> is element a in list b?",
       "a: any, b: any -> is str(b) in str(a)?"
     ) {
@@ -200,11 +209,12 @@ object Elements:
     ) {
       MiscHelpers.vyPrintln("sus")
     },
-    addElem(
+    addPart(
       Dyad,
       "C",
       "Count",
       List("count"),
+      false,
       "a: any, b: any -> count(b in a)"
     ) {
       case (a: VList, b) => a.count(_ === b)
@@ -212,11 +222,12 @@ object Elements:
       case (a, b) =>
         StringHelpers.countString(a.toString, b.toString)
     },
-    addElem(
+    addPart(
       Monad,
       "Ċ",
       "Cycle | Is Positive?",
       List("cycle", "is-positive?", "positive?", ">0?"),
+      false,
       "a: lst -> a ++ a ++ a ++ ...",
       "a: num -> a > 0"
     ) {
@@ -227,11 +238,12 @@ object Elements:
           VList.from(temp)
       case a: VNum => a > 0
     },
-    addVect(
+    addPart(
       Dyad,
       "÷",
       "Divide | Split",
       List("divide", "div", "str-split"),
+      true,
       "a: num, b: num -> a / b",
       "a: str, b: str -> Split a on the regex b"
     ) {
@@ -251,11 +263,12 @@ object Elements:
     ) { (a, b) =>
       NumberHelpers.divides(a, b)
     },
-    addElem(
+    addPart(
       Dyad,
       "ḋ",
       "Dot Product | To Bijective Base | First Index Where Predicate Truthy",
       List("dot-product", "bijective-base", "dot-prod", "first-index-where"),
+      false,
       "a: lst, b: lst -> Dot product of a and b",
       "a: num, b: num -> Convert a to bijective base b"
     ) {
@@ -273,11 +286,12 @@ object Elements:
           pos += 1
         if list.hasIndex(pos.toBigInt) then pos else VNum(-1)
     },
-    addVect(
+    addPart(
       Monad,
       "d",
       "Double",
       List("double"),
+      true,
       "a: num -> a * 2",
       "a: str -> a + a"
     ) {
@@ -291,11 +305,12 @@ object Elements:
 
     // todo extract to helper in MiscHelpers?
     ,
-    addVect(
+    addPart(
       Dyad,
       "=",
       "Equals",
       List("eq", "==", "equal", "same?", "equals?", "equal?"),
+      true,
       "a: any, b: any -> a == b"
     ) {
       case (a: VNum, b: VNum) => a == b
@@ -365,11 +380,12 @@ object Elements:
               )
             )
     },
-    addVect(
+    addPart(
       Dyad,
       "*",
       "Exponentation | Remove Nth Letter | Trim",
       List("exp", "**", "pow", "exponent", "remove-letter", "str-trim"),
+      true,
       "a: num, b: num -> a ^ b",
       "a: str, b: num -> a with the bth letter removed",
       "a: num, b: str -> b with the ath letter removed",
@@ -393,7 +409,7 @@ object Elements:
       None,
       "a ->"
     ) { ctx ?=> ctx.pop() },
-    addVect(
+    addPart(
       Monad,
       "K",
       "Factors | Is Numeric?",
@@ -406,17 +422,19 @@ object Elements:
         "is-num?",
         "is-number?"
       ),
+      true,
       "a: num -> Factors of a",
       "a: str -> Is a numeric?"
     ) {
       case a: VNum => NumberHelpers.factors(a)
       case a: String => VNum(VNum.DecimalRegex.matches(a))
     },
-    addVect(
+    addPart(
       Monad,
       "!",
       "Factorial | To Uppercase",
       List("fact", "factorial", "to-upper", "upper", "uppercase"),
+      true,
       "a: num -> a!",
       "a: str -> a.toUpperCase()"
     ) {
@@ -425,11 +443,12 @@ object Elements:
         else NumberHelpers.gamma(spire.math.abs(a.underlying.real) + 1)
       case a: String => a.toUpperCase()
     },
-    addElem(
+    addPart(
       Dyad,
       "F",
       "Filter by Function | From Base",
       List("filter", "keep-by", "from-base", "10->b"),
+      false,
       "a: fun, b: lst -> Filter b by truthy results of a",
       "a: lst, b: fun -> Filter a by truthy results of b",
       "a: num, b: num -> a from base b to base 10",
@@ -508,30 +527,33 @@ object Elements:
         if temp.nonEmpty then MiscHelpers.eval(temp)
         else ctx.settings.defaultValue
     },
-    addElem(
+    addPart(
       Monad,
       "↑",
       "Grade Up",
       List("grade-up"),
+      false,
       "a: any -> indices that will sort a"
     ) { a =>
       ListHelpers.gradeUp(a)
     },
-    addVect(
+    addPart(
       Dyad,
       ">",
       "Greater Than",
       List("gt", "greater", "greater-than", "greater?", "bigger?"),
+      true,
       "a: num, b: num -> a > b",
       "a: str, b: num -> a > str(b)",
       "a: num, b: str -> str(a) > b",
       "a: str, b: str -> a > b"
     ) { case (a: VVal, b: VVal) => a > b },
-    addElem(
+    addPart(
       Dyad,
       "Ġ",
       "Group by Function Result",
       List("group-by"),
+      false,
       "a: any, b: fun -> group a by the results of b",
       "a: fun, b: any -> group b by the results of a"
     ) {
@@ -564,11 +586,12 @@ object Elements:
         if s.nonEmpty then s.substring(1) else ""
       case a => ListHelpers.makeIterable(a).drop(1)
     },
-    addVect(
+    addPart(
       Monad,
       "H",
       "Hexadecimal | To Hexadecimal",
       List("hex", "hexadecimal", "to-hex", "to-hexadecimal"),
+      true,
       "a: num -> a in hexadecimal",
       "a: str -> a as a hexadecimal number to base 10"
     ) {
@@ -638,11 +661,12 @@ object Elements:
           )
         case arg => throw UnimplementedOverloadException("ṫ", List(arg))
     },
-    addElem(
+    addPart(
       Dyad,
       "i",
       "Index | Collect Unique Application Values | Enclose",
       List("index", "at", "item-at", "nth-item", "collect-unique", "enclose"),
+      false,
       "a: lst, b: num -> a[b]",
       "a: lst, b: lst -> a[_] for _ in b",
       "a: str, b: lst -> ''.join(a[i] for i in b)",
@@ -668,11 +692,12 @@ object Elements:
         val temp = a.length / 2
         a.slice(0, temp) + b + a.slice(temp, a.length)
     },
-    addElem(
+    addPart(
       Dyad,
       "İ",
       "Index into Multiple | Collect While Unique | Complex Number",
       List("index-into-multiple", "collect-while-unique", "complex"),
+      false,
       "a: num, b: num -> a.real + b.real * i",
       "a: any, b: lst -> `[a[item] for item in b]`",
       "a: any, b: fun -> Apply b on a and collect unique values (until fixpoint). Does not include the initial value."
@@ -693,22 +718,24 @@ object Elements:
           }
         )
     },
-    addElem(
+    addPart(
       Monad,
       "Ṫ",
       "Init",
       List("init", "remove-last"),
+      false,
       "a: lst -> a[:-1]",
       "a: str -> a[:-1]",
     ) {
       case lst: VList => lst.dropRight(1)
       case s: String => s.dropRight(1)
     },
-    addElem(
+    addPart(
       Dyad,
       "I",
       "Interleave",
       List("interleave"),
+      false,
       "a: lst, b: lst -> Interleave a and b"
     ) { case (a, b) =>
       val temp = ListHelpers.interleave(
@@ -718,7 +745,7 @@ object Elements:
       if a.isInstanceOf[String] && b.isInstanceOf[String] then temp.mkString
       else temp
     },
-    addVect(
+    addPart(
       Monad,
       "e",
       "Is Even / Split on Newlines",
@@ -730,6 +757,7 @@ object Elements:
         "newline-split",
         "split-newlines"
       ),
+      true,
       "a: num -> a % 2 == 0",
       "a: str -> a split on newlines"
     ) {
@@ -765,11 +793,12 @@ object Elements:
         case _ => ???
 
     },
-    addElem(
+    addPart(
       Dyad,
       "j",
       "Join On",
       List("join-on", "join", "join-with", "join-by"),
+      false,
       "a: lst, b: str|num -> a join on b",
       "a: lst, b: lst -> Intersperse elements of b within a"
     ) {
@@ -802,11 +831,12 @@ object Elements:
       "a: str -> is a alphanumeric?",
       "a: fun -> First positive integer ([1, 2, 3, ...]) for which a returns true"
     ) { a => MiscHelpers.joinNothing(a) },
-    addElem(
+    addPart(
       Monad,
       "L",
       "Length | Length of List",
       List("length", "len", "length-of", "len-of", "size"),
+      false,
       "a: any -> Length of a"
     ) {
       case a: VList => a.length
@@ -844,32 +874,35 @@ object Elements:
     ) { a =>
       range(0, ListHelpers.makeIterable(a).length - 1)
     },
-    addElem(
+    addPart(
       Monad,
       "κ",
       "Lenght 1-Range",
       List(
         "one->len"
       ),
+      false,
       "a: any -> `[1, 2, 3, ..., len(a)]`"
     ) { case a =>
       range(1, ListHelpers.makeIterable(a).length)
     },
-    addVect(
+    addPart(
       Dyad,
       "<",
       "Less Than",
       List("lt", "less", "less-than", "<", "less?", "smaller?"),
+      true,
       "a: num, b: num -> a < b",
       "a: str, b: num -> a < str(b)",
       "a: num, b: str -> str(a) < b",
       "a: str, b: str -> a < b"
     ) { case (a: VVal, b: VVal) => a < b },
-    addElem(
+    addPart(
       Dyad,
       "Y",
       "List Repeat",
       List("wrap-repeat"),
+      false,
       "a: any, b: num -> a repeated b times, wrapped in a list",
       "a: num, b: any -> b repeated a times, wrapped in a list",
       "a: lst|str, b: lst[num] -> a[_] repeated b[_] times, wrapped in a list",
@@ -899,7 +932,7 @@ object Elements:
           "Can't repeat an item a non-integer number of times"
         )
     },
-    addVect(
+    addPart(
       Dyad,
       "Ŀ",
       "Logarithm | Scan Fixpoint | Same Length? | Length Equals?",
@@ -914,6 +947,7 @@ object Elements:
         "length-equals",
         "len-eq?"
       ),
+      true,
       "a: num, b: num -> log_b(a)",
       "a: fun, b: any -> apply until a previous value is repeated, collecting intermediate results",
       "a: str, b: str -> a same length as b",
@@ -950,11 +984,12 @@ object Elements:
       Some(0),
       " -> continue the current loop"
     ) { throw ContinueLoopException() },
-    addElem(
+    addPart(
       Dyad,
       "M",
       "Map Function | Mold Lists | Multiplicity",
       List("map", "mold", "multiplicity", "times-divide"),
+      false,
       "a: any, b: fun -> a.map(b)",
       "a: fun, b: any -> b.map(a)",
       "a: lst, b: lst -> a molded to the shape of b",
@@ -991,11 +1026,12 @@ object Elements:
             case _ =>
               throw Exception("Invalid arguments for maximum")
     },
-    addElem(
+    addPart(
       Dyad,
       "J",
       "Merge",
       List("merge"),
+      false,
       "a: lst, b: lst -> Merge a and b",
       "a: any, b: lst -> Prepend a to b",
       "a: lst, b: any -> Append b to a",
@@ -1008,11 +1044,12 @@ object Elements:
       case (a: VNum, b: VNum) => MiscHelpers.eval(a.toString + b.toString)
       case (a, b) => a.toString + b.toString
     },
-    addElem(
+    addPart(
       Monad,
       "ṁ",
       "Mirror",
       List("mirror"),
+      false,
       "num a: a + reversed(a) (as number)",
       "str a: a + reversed(a)",
       "lst a: append reversed(a) to a"
@@ -1026,7 +1063,7 @@ object Elements:
       case a: String => a + a.reverse
       case a: VList => VList.from(a ++ a.reverse)
     },
-    addElem(
+    addPart(
       Dyad,
       "Ṁ",
       "Modular | Matrix Multiply | Regex Full Match?",
@@ -1039,6 +1076,7 @@ object Elements:
         "regex-full-match?",
         "full-match?"
       ),
+      false,
       "a: str|lst, b: num -> return every b-th element of a. If b is zero, mirror: prepend a to its reverse.",
       "a: num, b: str|lst -> return every a-th element of b. If a is zero, mirror: append b to its reverse.",
       "a: lst, b: lst -> a * b (matrix multiply)",
@@ -1097,7 +1135,7 @@ object Elements:
       "a: str, b: num -> a repeated b times",
       "a: str, b: str -> ring translate a according to b"
     )(MiscHelpers.multiply),
-    addVect(
+    addPart(
       Dyad,
       "ċ",
       "N Choose K | Character Set Equal?",
@@ -1109,6 +1147,7 @@ object Elements:
         "char-set-equal?",
         "char-set-eq?"
       ),
+      true,
       "a: num, b: num -> a choose b",
       "a: str, b: str -> are the character sets of a and b equal?"
     ) {
@@ -1116,7 +1155,7 @@ object Elements:
         if a > b then NumberHelpers.nChooseK(a, b) else 0
       case (a: String, b: String) => a.toSet == b.toSet
     },
-    addVect(
+    addPart(
       Monad,
       "N",
       "Negation | Swap Case | First Non-Negative Integer Where Predicate is True",
@@ -1129,6 +1168,7 @@ object Elements:
         "first-nonneg",
         "first>-1"
       ),
+      true,
       "a: num -> -a",
       "a: str -> a.swapCase()",
       "a: fun -> first non-negative integer where predicate a is true"
@@ -1137,11 +1177,12 @@ object Elements:
       case a: String => a.map(c => if c.isUpper then c.toLower else c.toUpper)
       case a: VFun => MiscHelpers.firstNonNegative(a)
     },
-    addElem(
+    addPart(
       Monad,
       "O",
       "Ord/Chr",
       List("ord", "chr"),
+      false,
       "a: str -> ord(a)",
       "a: num -> chr(a)"
     ) {
@@ -1198,11 +1239,12 @@ object Elements:
     addFull(Dyad, ";", "Pair", List("pair"), false, "a, b -> [a, b]") {
       VList(_, _)
     },
-    addElem(
+    addPart(
       Monad,
       "Ṗ",
       "Permutations",
       List("permutations", "perms"),
+      false,
       "a: lst -> Permutations of a"
     ) {
       case a: VNum =>
@@ -1219,11 +1261,12 @@ object Elements:
             .map(_.mkString)
         )
     },
-    addElem(
+    addPart(
       Monad,
       "P",
       "Prefixes",
       List("prefixes"),
+      false,
       "a: lst -> Prefixes of a"
     ) {
       case a: VList => VList.from(ListHelpers.prefixes(a))
@@ -1240,11 +1283,12 @@ object Elements:
             .map(n => MiscHelpers.eval(n.mkString))
         )
     },
-    addElem(
+    addPart(
       Dyad,
       "p",
       "Prepend",
       List("prepend"),
+      false,
       "a: lst, b: any -> b prepended to a"
     ) {
       case (a: String, b: (String | VNum)) => b.toString + a
@@ -1253,11 +1297,12 @@ object Elements:
       case (a: VList, b) => VList.from(b +: a)
       case (a, b) => VList(b, a)
     },
-    addVect(
+    addPart(
       Monad,
       "ḟ",
       "Prime Factors | Remove Non-Alphabet",
       List("prime-factors", "remove-non-alphabet"),
+      true,
       "a: num -> prime factors of a",
       "a: str -> a with all non-alphabet characters removed"
     ) {
@@ -1273,21 +1318,23 @@ object Elements:
     ) { ctx ?=>
       MiscHelpers.vyPrintln(ctx.pop())
     },
-    addElem(
+    addPart(
       Monad,
       "q",
       "Quotify",
       List("quotify"),
+      false,
       "a: any -> enclose a in quotes, escape backslashes and quote marks"
     ) {
       case a: String => StringHelpers.quotify(a)
       case a => StringHelpers.quotify(a.toString)
     },
-    addVect(
+    addPart(
       Monad,
       "ė",
       "Reciprocal | Remove Whitespace",
       List("reciprocal", "recip", "remove-whitespace", "remove-space", "1/"),
+      true,
       "a: num -> 1/a",
       "a: str -> a with all whitespace removed"
     ) {
@@ -1316,7 +1363,7 @@ object Elements:
         case _: String => VList.from(res.map(_.mkString))
         case _ => VList.from(res)
     },
-    addElem(
+    addPart(
       Monad,
       "ṗ",
       "List Partitions | Integer Partitions",
@@ -1327,6 +1374,7 @@ object Elements:
         "int-partitions",
         "int-parts",
       ),
+      false,
       "a: lst -> List partitions of a",
       "a: num -> Integer partitions of a (all possible ways to sum to a)"
     ) {
@@ -1356,7 +1404,7 @@ object Elements:
         throw RecursionError("No function to recurse")
       else ctx.push(Interpreter.executeFn(ctx.globals.callStack.top))
     },
-    addElem(
+    addPart(
       Dyad,
       "R",
       "Reduce by Function Object | Dyadic Range | Regex Match",
@@ -1371,6 +1419,7 @@ object Elements:
         "has-regex-match?",
         "fold"
       ),
+      false,
       "a: fun, b: any -> reduce iterable b by function a",
       "a: any, b: fun -> reduce iterable a by function b",
       "a: num, b: num -> the range [a, b)",
@@ -1386,11 +1435,12 @@ object Elements:
       case (a, b: VFun) =>
         ListHelpers.reduce(a, b)
     },
-    addElem(
+    addPart(
       Triad,
       "r",
       "Replace",
       List("replace"),
+      false,
       "a: str, b: str, c: str -> replace all instances of b in a with c"
     ) {
       case (a: VList, b, c) =>
@@ -1406,11 +1456,12 @@ object Elements:
       case (a: VNum, b: VVal, c: VVal) =>
         MiscHelpers.eval(a.toString().replace(b.toString, c.toString))
     },
-    addElem(
+    addPart(
       Monad,
       "Ṛ",
       "Reverse",
       List("reverse"),
+      false,
       "a: any -> reverse a"
     ) { a =>
       ListHelpers.reverse(a)
@@ -1456,11 +1507,12 @@ object Elements:
         case _: VNum => ctx.push(VNum(temp.mkString))
         case _ => ctx.push(temp)
     },
-    addElem(
+    addPart(
       Monad,
       "ṙ",
       "Rotate Right",
       List("abc->cab", "rot-right", "rotate-right"),
+      false,
       "a: any -> rotate right once"
     ) {
       case a: String => s"${a.last}${a.dropRight(1)}"
@@ -1468,7 +1520,7 @@ object Elements:
       case a: VList => VList.from(a.lst.last +: a.lst.dropRight(1))
 
     },
-    addElem(
+    addPart(
       Dyad,
       "ṡ",
       "Sort by Function Object | Partition by Numbers",
@@ -1481,6 +1533,7 @@ object Elements:
         "sortfun",
         "partition-by"
       ),
+      false,
       "a: fun, b: any -> sort iterable b by function a",
       "a: any, b: fun -> sort iterable a by function b",
       "a: lst, b: lst[num] -> partition a into sublists of length items in b"
@@ -1494,11 +1547,12 @@ object Elements:
           ListHelpers.partitionBy(a, b.lst.map(_.asInstanceOf[VNum]))
         else ???
     },
-    addElem(
+    addPart(
       Dyad,
       "s",
       "Split",
       List("split"),
+      false,
       "a: any, b: any -> split a by b"
     ) {
       case (a: String, b) =>
@@ -1511,7 +1565,7 @@ object Elements:
         )
       case (a: VList, b) => ListHelpers.splitNormal(a, b)
     },
-    addVect(
+    addPart(
       Dyad,
       "-",
       "Subtraction",
@@ -1524,6 +1578,7 @@ object Elements:
         "str-remove-all",
         "remove-all",
       ),
+      true,
       "a: num, b: num -> a - b",
       "a: str, b: num -> a + b '-'s (or '-'s + a if b < 0)",
       "a: num, b: str -> a '-'s + b (or b + '-'s if a < 0)",
@@ -1537,11 +1592,12 @@ object Elements:
       case (a: String, b: String) =>
         a.replace(b, "")
     },
-    addElem(
+    addPart(
       Monad,
       "∑",
       "Sum",
       List("sum", "/+", "+/"),
+      false,
       "a: lst -> sum of a"
     ) { case a =>
       ListHelpers.sum(ListHelpers.makeIterable(a))
@@ -1563,11 +1619,12 @@ object Elements:
         .lastOption
         .getOrElse(MiscHelpers.defaultEmpty(a))
     },
-    addElem(
+    addPart(
       Dyad,
       "y",
       "To Base",
       List("to-base"),
+      false,
       "a: num, b: num -> a in base b",
       "a: num, b: str|lst -> a in base with alphabet b",
       "a: lst, b: num -> each x in a in base b",
@@ -1576,11 +1633,12 @@ object Elements:
       case (a: VNum, b) => NumberHelpers.toBase(a, b)
       case (a: VList, b) => a.vmap(NumberHelpers.toBase(_, b))
     },
-    addElem(
+    addPart(
       Triad,
       "ŀ",
       "Transliterate | Call While",
       List("transliterate", "call-while"),
+      false,
       "any a, any b, any c -> transliterate(a,b,c) (in a, replace b[0] with c[0], b[1] with c[1], b[2] with c[2], ...)",
       "a: fun, b: fun, c: any -> call b on c until a(c) is falsy"
     ) {
@@ -1606,21 +1664,23 @@ object Elements:
             .mkString
         if VNum.NumRegex.matches(temp) then VNum(temp) else temp
     },
-    addElem(
+    addPart(
       Dyad,
       "ẋ",
       "Cartesian Power",
       List("cartesian-power"),
+      false,
       "a: lst, b: num -> cart_prod([a] * n)"
     ) {
       case (a, n: VNum) => ListHelpers.cartesianPower(a, n)
       case (n: VNum, a) => ListHelpers.cartesianPower(a, n)
     },
-    addElem(
+    addPart(
       Dyad,
       "⁾",
       "Surround | Character Multiply",
       List("surround", "character-multiply"),
+      false,
       "a: num, b: str -> each character in b repeated a times",
       "a: any, b: any -> a prepended and appended to b"
     ) {
@@ -1631,18 +1691,19 @@ object Elements:
       case (a: String, b: VNum) => StringHelpers.characterMultiply(b, a)
       case (a: VNum, b: VNum) => ??? // Doesn't say anything in info.txt
     },
-    addElem(
+    addPart(
       Monad,
       "ÞT",
       "Transpose Safe",
       List("transpose-safe"),
+      false,
       "a: any -> transpose a"
     ) {
       case a: VFun =>
         throw RuntimeException(s"Can't transpose (ÞT) function: $a")
       case a => ListHelpers.transposeSafe(ListHelpers.makeIterable(a))
     },
-    addElem(
+    addPart(
       Monad,
       "T",
       "Triple | Contains Only Alphabet | Transpose",
@@ -1658,6 +1719,7 @@ object Elements:
         "flip-axes",
         "permute-axes",
       ),
+      false,
       "a: num -> 3 * a",
       "a: str -> does a contain only alphabet characters?",
       "a: any -> transpose a"
@@ -1670,11 +1732,12 @@ object Elements:
       val a = ctx.pop()
       ctx.push(a, a, a)
     },
-    addVect(
+    addPart(
       Monad,
       "E",
       "2 Power | Evaluate",
       List("two^", "two**", "eval"),
+      true,
       "a: num -> 2^a",
       "a: str -> evaluate (not execute) a"
     ) {
@@ -1705,22 +1768,24 @@ object Elements:
 
       ctx.push(pushEven, pushOdd)
     },
-    addVect(
+    addPart(
       Monad,
       "Ḅ",
       "Unique Prime Factors | Case Of",
       List("unique-prime-factors", "case-of"),
+      true,
       "a: num -> unique prime factors of a",
       "a: str -> case of each character of a (uppercase = 1, lowercase = 0)"
     ) {
       case a: VNum => NumberHelpers.primeFactors(a).distinct
       case a: String => StringHelpers.caseof(a)
     },
-    addElem(
+    addPart(
       Monad,
       "u",
       "Uniquify",
       List("uniquify"),
+      false,
       "a: lst|str|num -> a with duplicates removed"
     ) {
       case lst: VList => lst.distinct
@@ -1815,7 +1880,7 @@ object Elements:
             "Reduce Columns: First argument should be a function"
           )
     },
-    addElem(
+    addPart(
       Monad,
       "V",
       "Vectorised Reverse | Complement | Title Case",
@@ -1826,6 +1891,7 @@ object Elements:
         "titlecase",
         "title-case"
       ),
+      false,
       "a: lst -> each element of a reversed",
       "a: num -> 1 - a",
       "a: str -> a converted to title case"
@@ -1834,7 +1900,7 @@ object Elements:
       case a: VNum => 1 - a
       case a: String => StringHelpers.titlecase(a)
     },
-    addElem(
+    addPart(
       Monad,
       "Ṡ",
       "Vectorised Sums",
@@ -1842,6 +1908,7 @@ object Elements:
         "vectorised-sums",
         "vec-sums",
       ),
+      false,
       "a: lst -> sum of each element of a",
     ) { case a: VList =>
       a.vmap(x => ListHelpers.sum(ListHelpers.makeIterable(x)))
@@ -1861,11 +1928,12 @@ object Elements:
       false,
       "a -> [a]"
     ) { a => VList(a) },
-    addElem(
+    addPart(
       Dyad,
       "Ẇ",
       "Wrap to Length | Predicate Slice From 0",
       List("wrap-length", "pred-slice-0"),
+      false,
       "a: lst, b: num -> a wrapped in chunks of length b",
       "a: fun, b: num -> first b truthy integers where a is truthy"
     ) {
@@ -1888,11 +1956,12 @@ object Elements:
       case (a: VFun, b: VNum) => MiscHelpers.predicateSlice(a, b, 0)
       case (a: VNum, b: VFun) => MiscHelpers.predicateSlice(b, a, 0)
     },
-    addVect(
+    addPart(
       Monad,
       "z",
       "Zero Range | Is Lowercase",
       List("zero-range", "zero->n", "is-lowercase?", "lowercase?", "lower?"),
+      true,
       "a: num -> [0, 1, ..., a]",
       "a: str -> is a lowercase?"
     ) {
@@ -1901,7 +1970,7 @@ object Elements:
         if a.length == 1 then a.forall(_.isLower)
         else VList.from(a.map(x => VNum(x.isLower)))
     },
-    addElem(
+    addPart(
       Dyad,
       "Θ",
       "Zero Slice Until",
@@ -1915,15 +1984,17 @@ object Elements:
         "first-n-items",
         "first-n"
       ),
+      false,
       "a: lst, b: num -> [a[0], a[1], ..., a[b-1]]"
     ) { case (a, b: VNum) =>
       ListHelpers.makeIterable(a, Some(true)).take(b.toInt)
     },
-    addElem(
+    addPart(
       Dyad,
       "Z",
       "Zip",
       List("zip", "zip-map"),
+      false,
       "a: lst, b: lst -> zip a and b",
       "a: lst, b: fun -> [[x, b(x)] for x in a]",
       "a: fun, b: lst -> [[a(x), x] for x in b]",
@@ -2007,7 +2078,7 @@ object Elements:
       () => ctx ?=> ctx.push(impl(using ctx))
     )
 
-  /** Add a monad that handles all `VAny`s (it doesn't take a `PartialFunction`,
+  /** Add an element that handles all `VAny`s (it doesn't take a `PartialFunction`,
     * hence "Full")
     */
   private def addFull[F](
@@ -2028,18 +2099,19 @@ object Elements:
       helper.toDirectFn(impl)
     )
 
-  /** Define an unvectorised element that doesn't necessarily work on all inputs
+  /** Define an element that doesn't necessarily work on all inputs
     *
     * If using this method, make sure to use `case` to define the function,
     * since it needs a `PartialFunction`. If it is possible to define it using a
     * normal function literal or it covers every single case, then try
     * [[addFull]] instead.
     */
-  private def addElem[P, F](
+  private def addPart[P, F](
       helper: ImplHelpers[P, F],
       symbol: String,
       name: String,
       keywords: Seq[String],
+      vectorises: Boolean,
       overloads: String*
   )(impl: P): (String, Element) =
     symbol -> Element(
@@ -2047,16 +2119,19 @@ object Elements:
       name,
       keywords,
       Some(helper.arity),
-      false,
+      vectorises,
       overloads,
-      helper.toDirectFn(helper.fill(symbol)(impl))
+      helper.toDirectFn(
+        if vectorises then helper.vectorise(symbol)(impl)
+        else helper.fill(symbol)(impl)
+      )
     )
 
   /** Define an element that doesn't necessarily work on all inputs. It may
     * vectorise on some inputs but not others.
     *
     * Note that this helper assumes you've already done the work of vectorising
-    * the element, i.e., unlike [[addVect]], vectorisation will not be done for
+    * the element, i.e., unlike [[addPart]], vectorisation will not be done for
     * you.
     *
     * If using this method, make sure to use `case` to define the function,
@@ -2079,27 +2154,6 @@ object Elements:
       true,
       overloads,
       helper.toDirectFn(helper.fill(symbol)(impl))
-    )
-
-  /** If using this method, make sure to use `case` to define the function,
-    * since it needs a `PartialFunction`. If it is possible to define it using a
-    * normal function literal, then try [[addFull]] instead.
-    */
-  private def addVect[P, F](
-      helper: ImplHelpers[P, F],
-      symbol: String,
-      name: String,
-      keywords: Seq[String],
-      overloads: String*
-  )(impl: P): (String, Element) =
-    symbol -> Element(
-      symbol,
-      name,
-      keywords,
-      Some(helper.arity),
-      true,
-      overloads,
-      helper.toDirectFn(helper.vectorise(symbol)(impl))
     )
 
   /** Add an element that works directly on the entire stack */

--- a/shared/src/vyxal/Elements.scala
+++ b/shared/src/vyxal/Elements.scala
@@ -2078,8 +2078,8 @@ object Elements:
       () => ctx ?=> ctx.push(impl(using ctx))
     )
 
-  /** Add an element that handles all `VAny`s (it doesn't take a `PartialFunction`,
-    * hence "Full")
+  /** Add an element that handles all `VAny`s (it doesn't take a
+    * `PartialFunction`, hence "Full")
     */
   private def addFull[F](
       helper: ImplHelpers[?, F],


### PR DESCRIPTION
@nayakrujul suggested that `addElem` take a `vectorises` argument like `addFull` for convenience. This PR merges `addElem` and `addVect` into a single `addPart` helper that takes a `vectorises` argument. This'll make `Elements.scala` longer, but it's one less helper to remember. There's like a billion changes in this PR, so enjoy reviewing!