### PR TITLE
Diagonalize sublists

### DIFF
--- a/shared/src/vyxal/Elements.scala
+++ b/shared/src/vyxal/Elements.scala
@@ -1483,12 +1483,13 @@ object Elements:
       false,
       "a: lst -> sublists of a",
     ) {
-      case a: (VVal | VList) =>
-        VList.from(ListHelpers.mergeInfLists(
-          ListHelpers
-            .prefixes(ListHelpers.makeIterable(a))
-            .map(b => ListHelpers.suffixes(ListHelpers.makeIterable(b)))
-        ))
+      case a: (VVal | VList) => VList.from(
+          ListHelpers.mergeInfLists(
+            ListHelpers
+              .prefixes(ListHelpers.makeIterable(a))
+              .map(b => ListHelpers.suffixes(ListHelpers.makeIterable(b)))
+          )
+        )
     },
     addPart(
       Monad,

--- a/shared/src/vyxal/Elements.scala
+++ b/shared/src/vyxal/Elements.scala
@@ -1483,12 +1483,10 @@ object Elements:
       false,
       "a: lst -> sublists of a",
     ) {
-      case a: (VVal | VList) => VList.from(
+      case a: (VVal | VList) => ListHelpers.mergeInfLists(
           ListHelpers
             .prefixes(ListHelpers.makeIterable(a))
-            .flatMap(b =>
-              VList.from(ListHelpers.suffixes(ListHelpers.makeIterable(b)))
-            )
+            .map(b => ListHelpers.suffixes(ListHelpers.makeIterable(b)))
         )
     },
     addPart(

--- a/shared/src/vyxal/Elements.scala
+++ b/shared/src/vyxal/Elements.scala
@@ -1483,11 +1483,12 @@ object Elements:
       false,
       "a: lst -> sublists of a",
     ) {
-      case a: (VVal | VList) => ListHelpers.mergeInfLists(
+      case a: (VVal | VList) =>
+        VList.from(ListHelpers.mergeInfLists(
           ListHelpers
             .prefixes(ListHelpers.makeIterable(a))
             .map(b => ListHelpers.suffixes(ListHelpers.makeIterable(b)))
-        )
+        ))
     },
     addPart(
       Monad,

--- a/shared/test/src/vyxal/ElementTests.scala
+++ b/shared/test/src/vyxal/ElementTests.scala
@@ -746,9 +746,31 @@ class ElementTests extends VyxalTests:
   describe("Ṣ") {
     testMulti(
       "#[1|1#]Ṇ+}Ṣ10Θ" ->
-        VList(VList(1), VList(1, 1), VList(1), VList(1, 1, 2), VList(1, 2), VList(1, 1, 2, 3), VList(2), VList(1, 2, 3), VList(1, 1, 2, 3, 5), VList(2, 3)),
+        VList(
+          VList(1),
+          VList(1, 1),
+          VList(1),
+          VList(1, 1, 2),
+          VList(1, 2),
+          VList(1, 1, 2, 3),
+          VList(2),
+          VList(1, 2, 3),
+          VList(1, 1, 2, 3, 5),
+          VList(2, 3),
+        ),
       "#[1#]Ṇ1+}Ṣ10Θ" ->
-        VList(VList(1), VList(1, 2), VList(2), VList(1, 2, 3), VList(2, 3), VList(1, 2, 3, 4), VList(3), VList(2, 3, 4), VList(1, 2, 3, 4, 5), VList(3, 4)),
+        VList(
+          VList(1),
+          VList(1, 2),
+          VList(2),
+          VList(1, 2, 3),
+          VList(2, 3),
+          VList(1, 2, 3, 4),
+          VList(3),
+          VList(2, 3, 4),
+          VList(1, 2, 3, 4, 5),
+          VList(3, 4),
+        ),
     )
   }
 

--- a/shared/test/src/vyxal/ElementTests.scala
+++ b/shared/test/src/vyxal/ElementTests.scala
@@ -746,31 +746,9 @@ class ElementTests extends VyxalTests:
   describe("Ṣ") {
     testMulti(
       "#[1|1#]Ṇ+}Ṣ10Θ" ->
-        VList(
-          VList(1),
-          VList(1, 1),
-          VList(1),
-          VList(1, 1, 2),
-          VList(1, 2),
-          VList(2),
-          VList(1, 1, 2, 3),
-          VList(1, 2, 3),
-          VList(2, 3),
-          VList(3),
-        ),
+        VList(VList(1), VList(1, 1), VList(1), VList(1, 1, 2), VList(1, 2), VList(1, 1, 2, 3), VList(2), VList(1, 2, 3), VList(1, 1, 2, 3, 5), VList(2, 3)),
       "#[1#]Ṇ1+}Ṣ10Θ" ->
-        VList(
-          VList(1),
-          VList(1, 2),
-          VList(2),
-          VList(1, 2, 3),
-          VList(2, 3),
-          VList(3),
-          VList(1, 2, 3, 4),
-          VList(2, 3, 4),
-          VList(3, 4),
-          VList(4),
-        ),
+        VList(VList(1), VList(1, 2), VList(2), VList(1, 2, 3), VList(2, 3), VList(1, 2, 3, 4), VList(3), VList(2, 3, 4), VList(1, 2, 3, 4, 5), VList(3, 4)),
     )
   }
 


### PR DESCRIPTION
Currently, the sublists element won't enumerate every sublist even given unlimited time, so this PR uses `mergeInfLists` to make sure every sublist is enumerated eventually (like cartesian product). Unlike cartesian product, I don't think people usually rely on the exact order of the sublists, so I think this change is probably fine?