### PR TITLE
Make it so that `Ǔ` and `ǔ` are considered monadic to modifiers.

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -1085,6 +1085,14 @@ def test_maximums_by():
     assert stack[-1] == [8, 9, 10, 11]
 
 
+def test_rotate_in_modifier():
+    stack = run_vyxal("⟨1|2|3⟩ ⟨4|5|6⟩ ⟨7|8|9⟩ WvǓ")
+    assert stack[-1] == [[2, 3, 1], [5, 6, 4], [8, 9, 7]]
+
+    stack = run_vyxal("⟨1|2|3⟩ ⟨4|5|6⟩ ⟨7|8|9⟩ Wvǔ")
+    assert stack[-1] == [[3, 1, 2], [6, 4, 5], [9, 7, 8]]
+
+
 def test_non_modular_index_out_of_bounds():
     try:
         stack = run_vyxal("`short` 420 Þḭ")

--- a/vyxal/elements.py
+++ b/vyxal/elements.py
@@ -263,7 +263,7 @@ else:
         + "    stack.append(rotate_left(lhs, rhs, ctx))\n"
         + "else:\n"
         + "    stack.append(rotate_left(rhs, 1, ctx))\n",
-        2,
+        1,
     ),
     "ǔ": (
         "rhs = pop(stack, 1, ctx)\n"
@@ -272,7 +272,7 @@ else:
         + "    stack.append(rotate_right(lhs, rhs, ctx))\n"
         + "else:\n"
         + "    stack.append(rotate_right(rhs, 1, ctx))\n",
-        2,
+        1,
     ),
     "¼": process_element("ctx.global_array.pop()", 0),
     "⅛": ("lhs = pop(stack,1,ctx); ctx.global_array.append(lhs)", 1),


### PR DESCRIPTION
<!-- Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal. The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-"). -->
