### PR TITLE
Make Scala.js emit module instead of script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ tests/test_extras.py
 temp.vy
 pages/vyxal.js
 pages/vyxal.js.map
+pages/helpText.js
+pages/helpText.js.map
+pages/internal-*
 pages/ShortDictionary.txt
 pages/LongDictionary.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.class
 *.log
 
+# Vim
+*.swp
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,7 @@ lazy val vyxal = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       Seq(
         "org.scala-js" %%% "scalajs-dom" % "2.8.0"
       ),
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) },
     // Where the compiled JS is output
     Compile / fastOptJS / artifactPath :=
       baseDirectory.value.getParentFile / "pages" / "vyxal.js",

--- a/build.sc
+++ b/build.sc
@@ -178,6 +178,18 @@ object js extends VyxalModule with ScalaJSModule {
       val res = super.fastLinkJS()
       os.copy.over(res.dest.path / "main.js", pagesDir / "vyxal.js")
       os.copy.over(res.dest.path / "main.js.map", pagesDir / "vyxal.js.map")
+
+      val generatedFiles = os
+        .walk(res.dest.path)
+        .filter(f =>
+          (f.ext == "js" || f.ext == "map") && f.last.startsWith("internal")
+        )
+      // move each file to pages directory
+      generatedFiles.foreach { file =>
+        println(file)
+        os.move(file, pagesDir / file.last)
+      }
+
       copyDicts()
       res
     }
@@ -188,6 +200,16 @@ object js extends VyxalModule with ScalaJSModule {
       os.copy.over(res.dest.path / "main.js", pagesDir / "vyxal.js")
       os.copy.over(res.dest.path / "main.js.map", pagesDir / "vyxal.js.map")
       copyDicts()
+      val generatedFiles = os
+        .walk(res.dest.path)
+        .filter(f =>
+          (f.ext == "js" || f.ext == "map") && f.last.startsWith("internal")
+        )
+      // move each file to pages directory
+      generatedFiles.foreach { file =>
+        println(file)
+        os.move(file, pagesDir / file.last)
+      }
       res
     }
 

--- a/build.sc
+++ b/build.sc
@@ -164,7 +164,7 @@ object js extends VyxalModule with ScalaJSModule {
   val platform = "js"
 
   def scalaJSVersion = "1.14.0"
-  def moduleKind = T { ModuleKind.NoModule }
+  def moduleKind = T { ModuleKind.ESModule }
 
   def ivyDeps =
     T {

--- a/build.sc
+++ b/build.sc
@@ -176,8 +176,10 @@ object js extends VyxalModule with ScalaJSModule {
   override def fastLinkJS =
     T {
       val res = super.fastLinkJS()
-      os.copy.over(res.dest.path / "main.js", pagesDir / "vyxal.js")
-      os.copy.over(res.dest.path / "main.js.map", pagesDir / "vyxal.js.map")
+      os.copy.over(res.dest.path / "vyxal.js", pagesDir / "vyxal.js")
+      os.copy.over(res.dest.path / "vyxal.js.map", pagesDir / "vyxal.js.map")
+      os.copy.over(res.dest.path / "helpText.js", pagesDir / "helpText.js")
+      os.copy.over(res.dest.path / "helpText.js.map", pagesDir / "helpText.js.map")
 
       val generatedFiles = os
         .walk(res.dest.path)
@@ -187,7 +189,7 @@ object js extends VyxalModule with ScalaJSModule {
       // move each file to pages directory
       generatedFiles.foreach { file =>
         println(file)
-        os.move(file, pagesDir / file.last)
+        os.move.over(file, pagesDir / file.last)
       }
 
       copyDicts()
@@ -197,8 +199,10 @@ object js extends VyxalModule with ScalaJSModule {
   override def fullLinkJS =
     T {
       val res = super.fastLinkJS()
-      os.copy.over(res.dest.path / "main.js", pagesDir / "vyxal.js")
-      os.copy.over(res.dest.path / "main.js.map", pagesDir / "vyxal.js.map")
+      os.copy.over(res.dest.path / "vyxal.js", pagesDir / "vyxal.js")
+      os.copy.over(res.dest.path / "vyxal.js.map", pagesDir / "vyxal.js.map")
+      os.copy.over(res.dest.path / "helpText.js", pagesDir / "helpText.js")
+      os.copy.over(res.dest.path / "helpText.js.map", pagesDir / "helpText.js.map")
       copyDicts()
       val generatedFiles = os
         .walk(res.dest.path)

--- a/build.sc
+++ b/build.sc
@@ -207,8 +207,7 @@ object js extends VyxalModule with ScalaJSModule {
         )
       // move each file to pages directory
       generatedFiles.foreach { file =>
-        println(file)
-        os.move(file, pagesDir / file.last)
+        os.move.over(file, pagesDir / file.last)
       }
       res
     }

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -20,30 +20,36 @@ object JSVyxal:
       printFunc: js.Function1[String, Unit],
   ): Unit =
     // todo take functions to print to custom stdout and stderr
-    if code.contains('h') then
-      val resultPromise: js.Promise[String] = js.dynamicImport {
-        HelpText().getHelpText
-      }
-      for result <- resultPromise.toFuture do printFunc(result)
-      return
-    val settings = Settings(online = true).withFlags(flags.toList)
-    val globals = Globals(
-      settings = settings,
-      printFn = printFunc,
-      inputs = Inputs(
-        inputs.split("\n").map(x => MiscHelpers.eval(x)(using Context())).toSeq
-      ),
-    )
+    if flags.contains('h') then return
+    else
+      val settings = Settings(online = true).withFlags(flags.toList)
+      val globals = Globals(
+        settings = settings,
+        printFn = printFunc,
+        inputs = Inputs(
+          inputs
+            .split("\n")
+            .map(x => MiscHelpers.eval(x)(using Context()))
+            .toSeq
+        ),
+      )
 
-    val ctx = Context(
-      inputs = inputs
-        .split("\n")
-        .map(x => MiscHelpers.eval(x)(using Context()))
-        .toIndexedSeq,
-      globals = globals,
-    )
-    Interpreter.execute(code)(using ctx)
+      val ctx = Context(
+        inputs = inputs
+          .split("\n")
+          .map(x => MiscHelpers.eval(x)(using Context()))
+          .toIndexedSeq,
+        globals = globals,
+      )
+      Interpreter.execute(code)(using ctx)
   end execute
+
+  @JSExport
+  def printHelpText(printFunc: js.Function1[String, Unit]): Unit =
+    val resultPromise: js.Promise[String] = js.dynamicImport {
+      HelpText().getHelpText
+    }
+    for result <- resultPromise.toFuture do printFunc(result)
 
   @JSExport
   def setShortDict(dict: String): Unit =

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -46,10 +46,7 @@ object JSVyxal:
 
   @JSExport
   def printHelpText(printFunc: js.Function1[String, Unit]): Unit =
-    val resultPromise: js.Promise[String] = js.dynamicImport {
-      HelpText().getHelpText
-    }
-    for result <- resultPromise.toFuture do printFunc(result)
+    js.dynamicImport { HelpText().getHelpText }.then { text => printFunc(text) }
 
   @JSExport
   def setShortDict(dict: String): Unit =

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -7,11 +7,13 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*
 
 /** To avoid loading Scopt with the JSVyxal object */
-class HelpText:
-  def getHelpText: String = CLI.helpText
+@JSExportTopLevel("HelpText", moduleID = "helpText")
+object HelpText:
+  @JSExport
+  def getHelpText(): String = CLI.helpText
 
 /** A bridge between the interpreter and JS */
-@JSExportTopLevel("Vyxal")
+@JSExportTopLevel("Vyxal", moduleID = "vyxal")
 object JSVyxal:
   @JSExport
   def execute(
@@ -46,10 +48,6 @@ object JSVyxal:
     )
     Interpreter.execute(code)(using ctx)
   end execute
-
-  @JSExport
-  def printHelpText(printFunc: js.Function1[String, Unit]): Unit =
-    js.dynamicImport { HelpText().getHelpText }.`then` { text => printFunc(text) }
 
   @JSExport
   def setShortDict(dict: String): Unit =

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -2,7 +2,6 @@ package vyxal
 
 import vyxal.parsing.Lexer
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -2,11 +2,14 @@ package vyxal
 
 import vyxal.parsing.Lexer
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*
 
 /** A bridge between the interpreter and JS */
+class HelpText:
+  def getHelpText: String = CLI.helpText
 @JSExportTopLevel("Vyxal")
 object JSVyxal:
   @JSExport
@@ -18,7 +21,10 @@ object JSVyxal:
   ): Unit =
     // todo take functions to print to custom stdout and stderr
     if code.contains('h') then
-      printFunc(CLI.helpText)
+      val resultPromise: js.Promise[String] = js.dynamicImport {
+        HelpText().getHelpText
+      }
+      for result <- resultPromise.toFuture do printFunc(result)
       return
     val settings = Settings(online = true).withFlags(flags.toList)
     val globals = Globals(

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -7,9 +7,11 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*
 
-/** A bridge between the interpreter and JS */
+/** To avoid loading Scopt with the JSVyxal object */
 class HelpText:
   def getHelpText: String = CLI.helpText
+
+/** A bridge between the interpreter and JS */
 @JSExportTopLevel("Vyxal")
 object JSVyxal:
   @JSExport
@@ -20,33 +22,35 @@ object JSVyxal:
       printFunc: js.Function1[String, Unit],
   ): Unit =
     // todo take functions to print to custom stdout and stderr
-    if flags.contains('h') then return
-    else
-      val settings = Settings(online = true).withFlags(flags.toList)
-      val globals = Globals(
-        settings = settings,
-        printFn = printFunc,
-        inputs = Inputs(
-          inputs
-            .split("\n")
-            .map(x => MiscHelpers.eval(x)(using Context()))
-            .toSeq
-        ),
-      )
 
-      val ctx = Context(
-        inputs = inputs
+    // The help flag should be handled in the JS
+    if flags.contains('h') then return
+
+    val settings = Settings(online = true).withFlags(flags.toList)
+    val globals = Globals(
+      settings = settings,
+      printFn = printFunc,
+      inputs = Inputs(
+        inputs
           .split("\n")
           .map(x => MiscHelpers.eval(x)(using Context()))
-          .toIndexedSeq,
-        globals = globals,
-      )
-      Interpreter.execute(code)(using ctx)
+          .toSeq
+      ),
+    )
+
+    val ctx = Context(
+      inputs = inputs
+        .split("\n")
+        .map(x => MiscHelpers.eval(x)(using Context()))
+        .toIndexedSeq,
+      globals = globals,
+    )
+    Interpreter.execute(code)(using ctx)
   end execute
 
   @JSExport
   def printHelpText(printFunc: js.Function1[String, Unit]): Unit =
-    js.dynamicImport { HelpText().getHelpText }.then { text => printFunc(text) }
+    js.dynamicImport { HelpText().getHelpText }.`then` { text => printFunc(text) }
 
   @JSExport
   def setShortDict(dict: String): Unit =

--- a/pages/index.html
+++ b/pages/index.html
@@ -41,7 +41,7 @@
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>
 
-<body> <!--onload="initCodeMirror(); decodeURL();  updateCount();"-->
+<body>
   <script>
     const resizeCodeBox = window.resizeCodeBox;
     const updateCount = window.updateCount;

--- a/pages/index.html
+++ b/pages/index.html
@@ -30,12 +30,22 @@
   <script defer src="https://unpkg.com/fuzzysort@2.0.1"></script>
   <link rel="stylesheet" href="https://vyxal.github.io/Vylight/mode-vyxal.css">
 
-  <script defer src="./vyxal.js"></script>
-  <script defer src="./main.js"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "os": "./os.module.js"
+      }
+    }
+  </script>
+  <script defer src="./main.js" type="module"></script>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>
 
-<body onload="initCodeMirror(); decodeURL();  updateCount();">
+<body> <!--onload="initCodeMirror(); decodeURL();  updateCount();"-->
+  <script>
+    const resizeCodeBox = window.resizeCodeBox;
+    const updateCount = window.updateCount;
+  </script>
   <textarea id=dummy style="visibility: hidden;position:absolute; height: 0px; font: size 20px;"></textarea>
   <h2 style="display: inline-block;"><a href="https://github.com/Vyxal/Vyxal/tree/version-3" target="_blank">Vyxal 3</a>
   </h2>

--- a/pages/main.js
+++ b/pages/main.js
@@ -1,10 +1,14 @@
+import { Vyxal } from "./vyxal.js";
+
 const $ = x => document.getElementById(x)
 
 var codepage = Vyxal.getCodepage()
 
-search = window
-glyphQuery = String.fromCharCode(0162, 105, 0143, 107)
-this.prevQuery = ""
+const search = window
+const glyphQuery = String.fromCharCode(0o162, 105, 0o143, 107)
+// this.prevQuery = ""
+
+let worker;
 
 const aliases = {
     "λ": ["la", "`l", "A\\"],
@@ -722,8 +726,19 @@ function cancelWorker(why) {
     return;
 }
 
+window.initCodeMirror = initCodeMirror
+window.decodeURL = decodeURL
+window.shareOptions = shareOptions
+window.updateCount = updateCount
+window.resizeCodeBox = resizeCodeBox
+window.Vyxal = Vyxal
+
 // set up event listeners for execution
 window.addEventListener("DOMContentLoaded", e => {
+    initCodeMirror()
+    decodeURL()
+    updateCount()
+
     const run = document.getElementById("run_button")
     const clear = document.getElementById("clear")
 
@@ -735,8 +750,8 @@ window.addEventListener("DOMContentLoaded", e => {
 
     async function do_run() {
         // generate random 32 character session string
-        sessioncode = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-        timeout = 10000
+        const sessioncode = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+        let timeout = 10000
         if (flags.value.includes("5")) {
             timeout = 5000;
         } else if (flags.value.includes("b")) {
@@ -751,7 +766,7 @@ window.addEventListener("DOMContentLoaded", e => {
         }
 
         let runButton = $('run_button');
-        worker = new Worker('./worker.js');
+        worker = new Worker('./worker.js', { type: "module" });
         worker.onmessage = function (e) {
             if (e.data.session != sessioncode) { return; }
             if (e.data.command == "done") { runButton.innerHTML = '<i class="fas fa-play-circle"></i>'; }
@@ -765,7 +780,6 @@ window.addEventListener("DOMContentLoaded", e => {
 
         output.value = ""
         extra.value = ""
-
 
         worker.postMessage({
             "mode": "run",
@@ -802,7 +816,6 @@ window.addEventListener("DOMContentLoaded", e => {
         glyphSearch()
         expandBoxes()
     })
-
 })
 
 document.addEventListener('keydown', (event) => {

--- a/pages/main.js
+++ b/pages/main.js
@@ -749,6 +749,13 @@ window.addEventListener("DOMContentLoaded", e => {
     const filter = document.getElementById("filterBox")
 
     async function do_run() {
+        if (flags.value.includes("h")) {
+            runButton.innerHTML = '<i class="fa fa-cog fa-spin"></i>';
+            Vyxal.printHelpText(s => output.value += s);
+            expandBoxes();
+            runButton.innerHTML = '<i class="fas fa-play-circle"></i>';
+            return;
+        }
         // generate random 32 character session string
         const sessioncode = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
         let timeout = 10000

--- a/pages/main.js
+++ b/pages/main.js
@@ -1,4 +1,5 @@
 import { Vyxal } from "./vyxal.js";
+import { HelpText } from "./helpText.js";
 
 const $ = x => document.getElementById(x)
 
@@ -749,9 +750,11 @@ window.addEventListener("DOMContentLoaded", e => {
     const filter = document.getElementById("filterBox")
 
     async function do_run() {
+        const runButton = $('run_button');
+
         if (flags.value.includes("h")) {
             runButton.innerHTML = '<i class="fa fa-cog fa-spin"></i>';
-            Vyxal.printHelpText(s => output.value += s);
+            output.value = HelpText.getHelpText();
             expandBoxes();
             runButton.innerHTML = '<i class="fas fa-play-circle"></i>';
             return;
@@ -772,7 +775,6 @@ window.addEventListener("DOMContentLoaded", e => {
             location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
         }
 
-        let runButton = $('run_button');
         worker = new Worker('./worker.js', { type: "module" });
         worker.onmessage = function (e) {
             if (e.data.session != sessioncode) { return; }

--- a/pages/os.module.js
+++ b/pages/os.module.js
@@ -1,0 +1,2 @@
+export const EOL = "\n";
+

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -1,5 +1,5 @@
 console.log("here")
-import * as Vyxal from "./vyxal.js"
+import { Vyxal } from "./vyxal.js"
 console.log("here2")
 console.log(Object.getOwnPropertyNames(Vyxal))
 //console.err("asdf")
@@ -12,6 +12,6 @@ self.addEventListener('message', function (e) {
     };
     Vyxal.setShortDict(data.shortDict)
     Vyxal.setLongDict(data.longDict)
-    // Vyxal.execute(data.code, data.inputs, data.flags, sendFn)
+    Vyxal.execute(data.code, data.inputs, data.flags, sendFn)
     this.postMessage({ "command": "done", "session": data.session })
 })

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -3,7 +3,7 @@ import * as Vyxal from "./vyxal.js"
 console.log("here2")
 console.log(Object.getOwnPropertyNames(Vyxal))
 //console.err("asdf")
-self.onmessage = (function (e) {
+self.addEventListener('message', function (e) {
     var data = e.data;
     console.log("Worker received: " + data.mode);
     const session = data.session;

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -1,6 +1,8 @@
-importScripts("./vyxal.js")
-
-self.addEventListener('message', function (e) {
+console.log("here")
+import { EOL } from "./os.module.js"
+console.log("here")
+//console.err("asdf")
+self.onmessage = (function (e) {
     var data = e.data;
     console.log("Worker received: " + data.mode);
     const session = data.session;

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -1,8 +1,5 @@
-console.log("here")
 import { Vyxal } from "./vyxal.js"
-console.log("here2")
-console.log(Object.getOwnPropertyNames(Vyxal))
-//console.err("asdf")
+
 self.addEventListener('message', function (e) {
     var data = e.data;
     console.log("Worker received: " + data.mode);

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -1,6 +1,7 @@
 console.log("here")
-import { EOL } from "./os.module.js"
-console.log("here")
+import * as Vyxal from "./vyxal.js"
+console.log("here2")
+console.log(Object.getOwnPropertyNames(Vyxal))
 //console.err("asdf")
 self.onmessage = (function (e) {
     var data = e.data;
@@ -11,6 +12,6 @@ self.onmessage = (function (e) {
     };
     Vyxal.setShortDict(data.shortDict)
     Vyxal.setLongDict(data.longDict)
-    Vyxal.execute(data.code, data.inputs, data.flags, sendFn)
+    // Vyxal.execute(data.code, data.inputs, data.flags, sendFn)
     this.postMessage({ "command": "done", "session": data.session })
 })


### PR DESCRIPTION
To be able to use the Scopt help text, we need module support. Unfortunately, modules are a huge pain to get working. This currently doesn't work. It looks like the line in the web worker where it imports `vyxal.js` makes it so that the web worker doesn't respond? If I replace `"./vyxal.js"` with `"./os.module.js"`, then it does at least print an error message.