### PR TITLE
Add a print limit to JS bridge

### DIFF
--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -27,10 +27,15 @@ object JSVyxal:
     // The help flag should be handled in the JS
     if flags.contains('h') then return
 
+    var printRequestCount = 0
+
     val settings = Settings(online = true).withFlags(flags.toList)
-    val globals = Globals(
+    val globals: Globals = Globals(
       settings = settings,
-      printFn = printFunc,
+      printFn = str =>
+        if printRequestCount <= 20000 then
+          printFunc(str)
+          printRequestCount += 1,
       inputs = Inputs(
         inputs.split("\n").map(x => MiscHelpers.eval(x)(using Context())).toSeq
       ),


### PR DESCRIPTION
So the idea here is that a program like:

```
Ṇ+|#[1|1#]}
```

(Fibonacci)

Will generate a lot of print function calls that will take a long time to all process. That's a IO speed problem that can't be avoided. The problem here is that these print function calls are continued to be processed after program execution has been terminated or halted early.

That's a lot of extra work for the browser, especially if several hundred thousand calls are queued. Therefore, I've added a print call limit of 20000. Ping me in chat if you want a better explanation.