### PR TITLE
Useful Error Handling

### DIFF
--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -50,7 +50,17 @@ object JSVyxal:
       globals = globals,
     )
     try Interpreter.execute(code)(using ctx)
-    catch case _: Exception => errorFunc("Code errored :(")
+    catch
+      case ex: VyxalException => errorFunc(
+          ex.getMessage() +
+          (if (ctx.settings.fullTrace) "\n" + ex.getStackTrace().mkString("\n")
+          else "")
+        )
+      case ex: Throwable => errorFunc(
+          "Unrecognized error" +
+          (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
+          else ", use the '--trace' flag for full traceback")
+        ) 
   end execute
 
   @JSExport

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -59,7 +59,7 @@ object JSVyxal:
       case ex: Throwable => errorFunc(
           "Unrecognized error" +
           (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
-          else ", use the '--trace' flag for full traceback")
+          else ", use the 'X' flag for full traceback")
         ) 
   end execute
 

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -21,7 +21,7 @@ object JSVyxal:
       inputs: String,
       flags: String,
       printFunc: js.Function1[String, Unit],
-      errorFunc: js.Function1[String, Unit]
+      errorFunc: js.Function1[String, Unit],
   ): Unit =
     // todo take functions to print to custom stdout and stderr
 
@@ -49,10 +49,8 @@ object JSVyxal:
         .toIndexedSeq,
       globals = globals,
     )
-    try
-      Interpreter.execute(code)(using ctx)
-    catch
-      case _: Exception => errorFunc("Code errored :(")
+    try Interpreter.execute(code)(using ctx)
+    catch case _: Exception => errorFunc("Code errored :(")
   end execute
 
   @JSExport

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -53,14 +53,16 @@ object JSVyxal:
     catch
       case ex: VyxalException => errorFunc(
           ex.getMessage() +
-          (if (ctx.settings.fullTrace) "\n" + ex.getStackTrace().mkString("\n")
-          else "")
+            (if ctx.settings.fullTrace then
+               "\n" + ex.getStackTrace().mkString("\n")
+             else "")
         )
       case ex: Throwable => errorFunc(
           "Unrecognized error" +
-          (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
-          else ", use the 'X' flag for full traceback")
-        ) 
+            (if ctx.settings.fullTrace then
+               ":\n" + ex.getStackTrace().mkString("\n")
+             else ", use the 'X' flag for full traceback")
+        )
   end execute
 
   @JSExport

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -21,6 +21,7 @@ object JSVyxal:
       inputs: String,
       flags: String,
       printFunc: js.Function1[String, Unit],
+      errorFunc: js.Function1[String, Unit]
   ): Unit =
     // todo take functions to print to custom stdout and stderr
 
@@ -48,7 +49,10 @@ object JSVyxal:
         .toIndexedSeq,
       globals = globals,
     )
-    Interpreter.execute(code)(using ctx)
+    try
+      Interpreter.execute(code)(using ctx)
+    catch
+      case _: Exception => errorFunc("Code errored :(")
   end execute
 
   @JSExport

--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -27,7 +27,10 @@ object JvmRepl extends Repl:
     println("Starting plain repl...")
     while true do
       val code = StdIn.readLine("> ")
-      Interpreter.execute(code)
+      try
+        Interpreter.execute(code)
+      catch
+        case ex: VyxalException => scribe.error(ex.getMessage(), if (ctx.settings.fullTrace) ex.getStackTrace.mkString("\n") else "")
 
   private def fancyRepl()(using ctx: Context): Unit =
     // Enable debug logging
@@ -76,6 +79,7 @@ object JvmRepl extends Repl:
         val code = lineReader.readLine("> ")
         Interpreter.execute(code)
       catch
+        case ex: VyxalException => scribe.error(ex.getMessage(), if (ctx.settings.fullTrace) ex.getStackTrace.mkString("\n") else "")
         case _: UserInterruptException => return
         case _: EndOfFileException => return
   end fancyRepl

--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -31,14 +31,18 @@ object JvmRepl extends Repl:
       catch
         case ex: VyxalException => scribe.error(
             ex.getMessage() +
-            (if ctx.settings.fullTrace then "\n" + ex.getStackTrace.mkString("\n")
-            else "")
+              (if ctx.settings.fullTrace then
+                 "\n" + ex.getStackTrace.mkString("\n")
+               else "")
           )
         case ex: Throwable => scribe.error(
             "Unrecognized error" +
-            (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
-            else ", use the '--trace' flag for full traceback")
+              (if ctx.settings.fullTrace then
+                 ":\n" + ex.getStackTrace().mkString("\n")
+               else ", use the '--trace' flag for full traceback")
           )
+    end while
+  end plainRepl
 
   private def fancyRepl()(using ctx: Context): Unit =
     // Enable debug logging
@@ -89,15 +93,18 @@ object JvmRepl extends Repl:
       catch
         case ex: VyxalException => scribe.error(
             ex.getMessage() +
-            (if ctx.settings.fullTrace then "\n" + ex.getStackTrace.mkString("\n")
-            else "")
+              (if ctx.settings.fullTrace then
+                 "\n" + ex.getStackTrace.mkString("\n")
+               else "")
           )
         case ex: Throwable => scribe.error(
             "Unrecognized error" +
-            (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
-            else ", use the '--trace' flag for full traceback")
+              (if ctx.settings.fullTrace then
+                 ":\n" + ex.getStackTrace().mkString("\n")
+               else ", use the '--trace' flag for full traceback")
           )
         case _: UserInterruptException => return
         case _: EndOfFileException => return
+    end while
   end fancyRepl
 end JvmRepl

--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -27,10 +27,13 @@ object JvmRepl extends Repl:
     println("Starting plain repl...")
     while true do
       val code = StdIn.readLine("> ")
-      try
-        Interpreter.execute(code)
+      try Interpreter.execute(code)
       catch
-        case ex: VyxalException => scribe.error(ex.getMessage(), if (ctx.settings.fullTrace) ex.getStackTrace.mkString("\n") else "")
+        case ex: VyxalException => scribe.error(
+            ex.getMessage(),
+            if ctx.settings.fullTrace then ex.getStackTrace.mkString("\n")
+            else "",
+          )
 
   private def fancyRepl()(using ctx: Context): Unit =
     // Enable debug logging
@@ -79,7 +82,11 @@ object JvmRepl extends Repl:
         val code = lineReader.readLine("> ")
         Interpreter.execute(code)
       catch
-        case ex: VyxalException => scribe.error(ex.getMessage(), if (ctx.settings.fullTrace) ex.getStackTrace.mkString("\n") else "")
+        case ex: VyxalException => scribe.error(
+            ex.getMessage(),
+            if ctx.settings.fullTrace then ex.getStackTrace.mkString("\n")
+            else "",
+          )
         case _: UserInterruptException => return
         case _: EndOfFileException => return
   end fancyRepl

--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -91,6 +91,8 @@ object JvmRepl extends Repl:
         val code = lineReader.readLine("> ")
         Interpreter.execute(code)
       catch
+        case _: UserInterruptException => return
+        case _: EndOfFileException => return
         case ex: VyxalException => scribe.error(
             ex.getMessage() +
               (if ctx.settings.fullTrace then
@@ -103,8 +105,6 @@ object JvmRepl extends Repl:
                  ":\n" + ex.getStackTrace().mkString("\n")
                else ", use the '--trace' flag for full traceback")
           )
-        case _: UserInterruptException => return
-        case _: EndOfFileException => return
     end while
   end fancyRepl
 end JvmRepl

--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -30,9 +30,14 @@ object JvmRepl extends Repl:
       try Interpreter.execute(code)
       catch
         case ex: VyxalException => scribe.error(
-            ex.getMessage(),
-            if ctx.settings.fullTrace then ex.getStackTrace.mkString("\n")
-            else "",
+            ex.getMessage() +
+            (if ctx.settings.fullTrace then "\n" + ex.getStackTrace.mkString("\n")
+            else "")
+          )
+        case ex: Throwable => scribe.error(
+            "Unrecognized error" +
+            (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
+            else ", use the '--trace' flag for full traceback")
           )
 
   private def fancyRepl()(using ctx: Context): Unit =
@@ -83,9 +88,14 @@ object JvmRepl extends Repl:
         Interpreter.execute(code)
       catch
         case ex: VyxalException => scribe.error(
-            ex.getMessage(),
-            if ctx.settings.fullTrace then ex.getStackTrace.mkString("\n")
-            else "",
+            ex.getMessage() +
+            (if ctx.settings.fullTrace then "\n" + ex.getStackTrace.mkString("\n")
+            else "")
+          )
+        case ex: Throwable => scribe.error(
+            "Unrecognized error" +
+            (if (ctx.settings.fullTrace) ":\n" + ex.getStackTrace().mkString("\n")
+            else ", use the '--trace' flag for full traceback")
           )
         case _: UserInterruptException => return
         case _: EndOfFileException => return

--- a/jvm/src/vyxal/Main.scala
+++ b/jvm/src/vyxal/Main.scala
@@ -2,7 +2,10 @@ package vyxal
 
 object Main:
   def main(args: Array[String]): Unit =
-    try
-      CLI.run(args, JvmRepl)
+    try CLI.run(args, JvmRepl)
     catch
-      case ex: VyxalException => scribe.error(ex.getMessage(), if (args contains "--trace") ex.getStackTrace.mkString("\n") else "")
+      case ex: VyxalException => scribe.error(
+          ex.getMessage(),
+          if args contains "--trace" then ex.getStackTrace.mkString("\n")
+          else "",
+        )

--- a/jvm/src/vyxal/Main.scala
+++ b/jvm/src/vyxal/Main.scala
@@ -1,4 +1,8 @@
 package vyxal
 
 object Main:
-  def main(args: Array[String]): Unit = CLI.run(args, JvmRepl)
+  def main(args: Array[String]): Unit =
+    try
+      CLI.run(args, JvmRepl)
+    catch
+      case ex: VyxalException => scribe.error(ex.getMessage(), if (args contains "--trace") ex.getStackTrace.mkString("\n") else "")

--- a/jvm/src/vyxal/MainLit.scala
+++ b/jvm/src/vyxal/MainLit.scala
@@ -4,4 +4,7 @@ object MainLit:
   def main(args: Array[String]): Unit =
     // Append the -l flag to the args
     val newArgs = args :+ "--literate"
-    CLI.run(newArgs, JvmRepl)
+    try
+      CLI.run(newArgs, JvmRepl)
+    catch
+      case ex: VyxalException => scribe.error(ex.getMessage(), if (args contains "--trace") ex.getStackTrace.mkString("\n") else "")

--- a/jvm/src/vyxal/MainLit.scala
+++ b/jvm/src/vyxal/MainLit.scala
@@ -4,7 +4,10 @@ object MainLit:
   def main(args: Array[String]): Unit =
     // Append the -l flag to the args
     val newArgs = args :+ "--literate"
-    try
-      CLI.run(newArgs, JvmRepl)
+    try CLI.run(newArgs, JvmRepl)
     catch
-      case ex: VyxalException => scribe.error(ex.getMessage(), if (args contains "--trace") ex.getStackTrace.mkString("\n") else "")
+      case ex: VyxalException => scribe.error(
+          ex.getMessage(),
+          if args contains "--trace" then ex.getStackTrace.mkString("\n")
+          else "",
+        )

--- a/pages/main.js
+++ b/pages/main.js
@@ -781,8 +781,13 @@ window.addEventListener("DOMContentLoaded", e => {
             if (e.data.session != sessioncode || !runButton.innerHTML.includes('fa-spin')) {
                 return;
             }
-            if (e.data.command == "done") { runButton.innerHTML = '<i class="fas fa-play-circle"></i>'; }
-            else { output.value += e.data.val; expandBoxes() }
+            if (e.data.command == "done") {
+                runButton.innerHTML = '<i class="fas fa-play-circle"></i>';
+            }
+            else if (e.data.command == "error") {
+                console.log("test error");
+            }
+            else { output.value += e.data.val; expandBoxes(); }
         }
         if (runButton.innerHTML.includes('fa-spin')) {
             cancelWorker("Code terminated by user")

--- a/pages/main.js
+++ b/pages/main.js
@@ -785,7 +785,7 @@ window.addEventListener("DOMContentLoaded", e => {
                 runButton.innerHTML = '<i class="fas fa-play-circle"></i>';
             }
             else if (e.data.command == "error") {
-                console.log("test error");
+                extra.value += e.data.val; expandBoxes();
             }
             else { output.value += e.data.val; expandBoxes(); }
         }

--- a/pages/worker.js
+++ b/pages/worker.js
@@ -7,8 +7,11 @@ self.addEventListener('message', function (e) {
     const sendFn = x => {
         this.postMessage({ "val": x, "command": "append", "session": session })
     };
+    const errorFn = x => {
+        this.postMessage({ "val": x, "command": "error", "session": session })
+    };
     Vyxal.setShortDict(data.shortDict)
     Vyxal.setLongDict(data.longDict)
-    Vyxal.execute(data.code, data.inputs, data.flags, sendFn)
+    Vyxal.execute(data.code, data.inputs, data.flags, sendFn, errorFn)
     this.postMessage({ "command": "done", "session": data.session })
 })

--- a/shared/src/vyxal/CLI.scala
+++ b/shared/src/vyxal/CLI.scala
@@ -158,14 +158,6 @@ object CLI:
         .text(text)
         .optional()
 
-    def longFlag(long: String, text: String) =
-      opt[Unit](long)
-        .action((_, cfg) =>
-          cfg.copy(settings = cfg.settings.withLongFlag(long))
-        )
-        .text(text)
-        .optional()
-
     // todo come up with better names for the flags
     OParser.sequence(
       programName("vyxal"),
@@ -177,7 +169,7 @@ object CLI:
         .action((_, cfg) => cfg.copy(printHelp = true))
         .text("Print this help message and exit")
         .optional(),
-      longFlag("trace", "Return full traceback on program error"),
+      flag('X', "trace", "Return full traceback on program error"),
       opt[String]("file")
         .action((file, cfg) => cfg.copy(filename = Some(file)))
         .text("The file to read the program from")

--- a/shared/src/vyxal/CLI.scala
+++ b/shared/src/vyxal/CLI.scala
@@ -110,7 +110,6 @@ object CLI:
                     "Either file name or code must be given to debug"
                   )
           DebugRepl.start(code)
-
         else if config.readBytes then
           config.filename.foreach { filename =>
             val fileObj = java.io.File(filename)
@@ -161,7 +160,9 @@ object CLI:
 
     def longFlag(long: String, text: String) =
       opt[Unit](long)
-        .action((_, cfg) => cfg.copy(settings = cfg.settings.withLongFlag(long)))
+        .action((_, cfg) =>
+          cfg.copy(settings = cfg.settings.withLongFlag(long))
+        )
         .text(text)
         .optional()
 

--- a/shared/src/vyxal/CLI.scala
+++ b/shared/src/vyxal/CLI.scala
@@ -110,6 +110,7 @@ object CLI:
                     "Either file name or code must be given to debug"
                   )
           DebugRepl.start(code)
+
         else if config.readBytes then
           config.filename.foreach { filename =>
             val fileObj = java.io.File(filename)
@@ -151,10 +152,16 @@ object CLI:
   private val parser =
     import builder.*
 
-    /** Helper to for adding flags that go into Settings */
+    /** Helpers for adding flags that go into Settings */
     def flag(short: Char, name: String, text: String) =
       opt[Unit](short, name)
         .action((_, cfg) => cfg.copy(settings = cfg.settings.withFlag(short)))
+        .text(text)
+        .optional()
+
+    def longFlag(long: String, text: String) =
+      opt[Unit](long)
+        .action((_, cfg) => cfg.copy(settings = cfg.settings.withLongFlag(long)))
         .text(text)
         .optional()
 
@@ -169,6 +176,7 @@ object CLI:
         .action((_, cfg) => cfg.copy(printHelp = true))
         .text("Print this help message and exit")
         .optional(),
+      longFlag("trace", "Return full traceback on program error"),
       opt[String]("file")
         .action((file, cfg) => cfg.copy(filename = Some(file)))
         .text("The file to read the program from")

--- a/shared/src/vyxal/Exceptions.scala
+++ b/shared/src/vyxal/Exceptions.scala
@@ -3,7 +3,9 @@ package vyxal
 class VyxalException(message: String) extends RuntimeException(message)
 
 case class UnimplementedOverloadException(element: String, args: Seq[VAny])
-  extends VyxalException(s"$element not supported for input(s) ${args.mkString("[", ", ", "]")}")
+    extends VyxalException(
+      s"$element not supported for input(s) ${args.mkString("[", ", ", "]")}"
+    )
 
 /** Exception to end program using element Q */
 class QuitException extends VyxalException("Program quit")

--- a/shared/src/vyxal/Exceptions.scala
+++ b/shared/src/vyxal/Exceptions.scala
@@ -1,29 +1,29 @@
 package vyxal
 
+class VyxalException(message: String) extends RuntimeException(message)
+
 case class UnimplementedOverloadException(element: String, args: Seq[VAny])
-    extends RuntimeException(
-      s"$element not supported for input(s) ${args.mkString("[", ", ", "]")}"
-    )
+  extends VyxalException(s"$element not supported for input(s) ${args.mkString("[", ", ", "]")}")
 
 /** Exception to end program using element Q */
-class QuitException extends RuntimeException("Program quit")
+class QuitException extends VyxalException("Program quit")
 
 /** Exception to signal that a loop should continue. Should technically never be
   * unhandled.
   */
 class ContinueLoopException
-    extends RuntimeException("Tried to continue outside of a loop context")
+    extends VyxalException("Tried to continue outside of a loop context")
 
 /** Exception to signal that a loop should break. Should technically never be
   * unhandled.
   */
 class BreakLoopException
-    extends RuntimeException("Tried to break outside of a loop context")
+    extends VyxalException("Tried to break outside of a loop context")
 
 /** Exception to signal that a function should return. Should technically never
   * be unhandled.
   */
 class ReturnFromFunctionException
-    extends RuntimeException("Tried to return outside of a function context")
+    extends VyxalException("Tried to return outside of a function context")
 
-class RecursionError(message: String) extends RuntimeException(message)
+class RecursionError(message: String) extends VyxalException(message)

--- a/shared/src/vyxal/Globals.scala
+++ b/shared/src/vyxal/Globals.scala
@@ -167,11 +167,7 @@ case class Settings(
       case 'N' => this.copy(endPrintMode = EndPrintMode.JoinNothing)
       case 'Ṫ' => this.copy(endPrintMode = EndPrintMode.SumStack)
       case 'ṡ' => this.copy(endPrintMode = EndPrintMode.SpaceStack)
-      case _ => throw IllegalArgumentException(s"$flag is an invalid flag")
-
-  def withLongFlag(flag: String): Settings =
-    flag match
-      case "trace" => this.copy(fullTrace = true)
+      case 'X' => this.copy(fullTrace = true)
       case _ => throw IllegalArgumentException(s"$flag is an invalid flag")
 
   /** Helper to update these settings with multiple flags

--- a/shared/src/vyxal/Globals.scala
+++ b/shared/src/vyxal/Globals.scala
@@ -140,6 +140,7 @@ case class Settings(
     numToRange: Boolean = false,
     online: Boolean = false,
     literate: Boolean = false,
+    fullTrace: Boolean = false,
 ):
 
   /** Add a flag to these settings
@@ -166,6 +167,11 @@ case class Settings(
       case 'N' => this.copy(endPrintMode = EndPrintMode.JoinNothing)
       case 'Ṫ' => this.copy(endPrintMode = EndPrintMode.SumStack)
       case 'ṡ' => this.copy(endPrintMode = EndPrintMode.SpaceStack)
+      case _ => throw IllegalArgumentException(s"$flag is an invalid flag")
+
+  def withLongFlag(flag: String): Settings =
+    flag match
+      case "trace" => this.copy(fullTrace = true)
       case _ => throw IllegalArgumentException(s"$flag is an invalid flag")
 
   /** Helper to update these settings with multiple flags


### PR DESCRIPTION
Some error handling additions
+ Errors in JVM REPL are handled and reported without crashing the REPL
+ Errors in online interpreter stop execution and are reported in the "Debug" box
+ All reported errors have short, unobtrusive messages explaining what happened
+ Full stack trace of reported errors can be enabled with `-X` or `--trace` flags