### PR TITLE
Fix apply to head

### DIFF
--- a/shared/src/vyxal/Exceptions.scala
+++ b/shared/src/vyxal/Exceptions.scala
@@ -42,6 +42,10 @@ class BadModifierException(modifier: String)
     extends VyxalParsingException(s"Modifier '$modifier' is missing arguments")
 class BadStructureException(structure: String)
     extends VyxalParsingException(s"Invalid $structure statement")
+class ModifierArityException(modifier: String, arity: Option[Int])
+    extends VyxalParsingException(
+      s"Modifier '$modifier' does not support elements of arity ${arity.getOrElse("None")}"
+    )
 class NoSuchElementException(element: String)
     extends VyxalParsingException(s"No such element: $element"):
   def this(token: Token) = this(token.value)

--- a/shared/src/vyxal/Modifiers.scala
+++ b/shared/src/vyxal/Modifiers.scala
@@ -265,10 +265,9 @@ object Modifiers:
                   () =>
                     ctx ?=>
                       val head = ctx.pop()
-                      val tail =
-                        if ctx.peek.isInstanceOf[VList] then
-                          ctx.pop().asInstanceOf[VList]
-                        else VList.from(ctx.pop(1))
+                      val tail = ctx.peek match
+                        case _: VList => ctx.pop().asInstanceOf[VList]
+                        case _ => VList.from(ctx.pop(1))
                       val list = VList.from(head +: tail)
                       if returnStr then
                         ctx.push(ListHelpers.flatten(list).mkString)
@@ -292,10 +291,9 @@ object Modifiers:
                 AST.Generated(
                   () =>
                     ctx ?=>
-                      val head =
-                        if ctx.peek.isInstanceOf[VList] then
-                          ctx.pop().asInstanceOf[VList]
-                        else VList.from(ctx.pop(1))
+                      val head = ctx.peek match
+                        case _: VList => ctx.pop().asInstanceOf[VList]
+                        case _ => VList.from(ctx.pop(1))
                       if returnStr then
                         ctx.push(ListHelpers.flatten(head).mkString)
                       else ctx.push(head)

--- a/shared/src/vyxal/Modifiers.scala
+++ b/shared/src/vyxal/Modifiers.scala
@@ -300,10 +300,11 @@ object Modifiers:
                         ctx.push(ListHelpers.flatten(head).mkString)
                       else ctx.push(head)
                   ,
-                  arity = Some(1)
+                  arity = Some(1),
                 ),
               )
             case _ => throw ModifierArityException("ᴴ", ast.arity)
+          end match
       },
     "ᶤ" ->
       Modifier(

--- a/shared/test/src/vyxal/ModifierTests.scala
+++ b/shared/test/src/vyxal/ModifierTests.scala
@@ -91,7 +91,8 @@ class ModifierTests extends VyxalTests:
       "\"abcde\"ᴴ+" -> "bacadaea",
       "#[3|4|\"abc\"#]ᴴ+" -> VList(7, "abc3"),
       "#[#[1|\"abc\"#]|2|\"def\"#]ᴴN" -> VList(VList(-1, "ABC"), 2, "def"),
-      "#[#[1|\"abc\"#]|2|\"def\"#]ᴴ+" -> VList(VList(3, "2abc"), VList("def1", "defabc")),
+      "#[#[1|\"abc\"#]|2|\"def\"#]ᴴ+" ->
+        VList(VList(3, "2abc"), VList("def1", "defabc")),
     )
   }
 

--- a/shared/test/src/vyxal/ModifierTests.scala
+++ b/shared/test/src/vyxal/ModifierTests.scala
@@ -83,7 +83,15 @@ class ModifierTests extends VyxalTests:
 
   describe("Modifier ᴴ") {
     testMulti(
-      "#[3|4|5#]ᴴd" -> VList(6, 4, 5)
+      "#[3|4|5#]ᴴ69" -> VList(69, 4, 5),
+      "#[3|4|5#]ᴴd" -> VList(6, 4, 5),
+      "#[3|4|5#]ᴴ+" -> VList(7, 8),
+      "\"abcde\"ᴴ69" -> "69bcde",
+      "\"abcde\"ᴴd" -> "aabcde",
+      "\"abcde\"ᴴ+" -> "bacadaea",
+      "#[3|4|\"abc\"#]ᴴ+" -> VList(7, "abc3"),
+      "#[#[1|\"abc\"#]|2|\"def\"#]ᴴN" -> VList(VList(-1, "ABC"), 2, "def"),
+      "#[#[1|\"abc\"#]|2|\"def\"#]ᴴ+" -> VList(VList(3, "2abc"), VList("def1", "defabc")),
     )
   }
 


### PR DESCRIPTION
<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
Fixes some issues that were happening with typecasting, and also defined behavior for nilads and dyads.

The changed behavior is just defining previously unspecified behavior, but it is technically a breaking change. On the off-chance that anybody is making use of the undefined behavior (highly unlikely), it'll probably break.

Closes #2017 