### PR TITLE
Fix JVM `YamlTests` on Windows

### DIFF
--- a/shared/test/src/vyxal/YamlTests.scala
+++ b/shared/test/src/vyxal/YamlTests.scala
@@ -130,7 +130,7 @@ class YamlTests extends AnyFunSpec:
 
   /** Load all the tests, mapping elements to test groups */
   private def loadTests(): Map[String, TestGroup] =
-    val file = Source.fromInputStream(getClass().getResourceAsStream(TestsFile))
+    val file = Source.fromInputStream(getClass().getResourceAsStream(TestsFile))(using io.Codec.UTF8)
     val yaml = file.mkString
     file.close()
 


### PR DESCRIPTION
Explicitly pass UTF8 encoding when reading the `tests.yaml` file

<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
