### PR TITLE
Avoid stack overflow when compiling lexers

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -23,9 +23,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: true
 
-env:
-  JAVA_OPTS: ${{ vars.JAVA_OPTS }}
-
 jobs:
   # Single deploy job since we're just deploying
   deploy:
@@ -47,10 +44,10 @@ jobs:
           distribution: "adopt"
 
       - name: Scala to JS
-        run: ./mill --no-server js.fullLinkJS
+        run: ./milljs.fullLinkJS
 
       - name: Generate files for web interpreter
-        run: ./mill --no-server jvm.theseus
+        run: ./milljvm.theseus
 
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -44,10 +44,10 @@ jobs:
           distribution: "adopt"
 
       - name: Scala to JS
-        run: ./milljs.fullLinkJS
+        run: ./mill js.fullLinkJS
 
       - name: Generate files for web interpreter
-        run: ./milljvm.theseus
+        run: ./mill jvm.theseus
 
       - name: Upload built HTML
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build executable
-        run: ./millnative.nativeLink
+        run: ./mill native.nativeLink
       - uses: olegtarasov/get-tag@v2.1.2
         id: tagName
       - name: Name executable (Linux/MacOS)
@@ -69,7 +69,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build jar
-        run: ./milljvm.assembly
+        run: ./mill jvm.assembly
 
       - name: Make artifacts folder
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ env:
   LINUX_NAME: vyxal-linux
   WINDOWS_NAME: vyxal-windows
   MACOS_NAME: vyxal-macos
-  JAVA_OPTS: ${{ vars.JAVA_OPTS }}
 
 jobs:
   native-exes:
@@ -41,7 +40,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build executable
-        run: ./mill --no-server native.nativeLink
+        run: ./millnative.nativeLink
       - uses: olegtarasov/get-tag@v2.1.2
         id: tagName
       - name: Name executable (Linux/MacOS)
@@ -70,7 +69,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build jar
-        run: ./mill --no-server jvm.assembly
+        run: ./milljvm.assembly
 
       - name: Make artifacts folder
         run: |

--- a/.github/workflows/resources.yaml
+++ b/.github/workflows/resources.yaml
@@ -7,9 +7,6 @@ on:
       - "contributing/**"
       - "pages/**"
 
-env:
-  JAVA_OPTS: ${{ vars.JAVA_OPTS }}
-
 jobs:
   lint:
     name: Lint and format
@@ -26,7 +23,7 @@ jobs:
         run: scalafix --check --syntactic --scala-version=3.3.0 shared jvm js native
       - name: Run Scalafmt
         run: |
-          ./mill --no-server mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources
+          ./millmill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources
       - name: Stage changes
         run: git add .
       - name: Commit and push
@@ -47,9 +44,9 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Update all documentation files
-        run: ./mill --no-server jvm.docs
+        run: ./milljvm.docs
       - name: Update nanorc files for JLine
-        run: ./mill --no-server jvm.nanorc
+        run: ./milljvm.nanorc
       - name: Stage changes
         run: git add .
       - name: Commit and push

--- a/.github/workflows/resources.yaml
+++ b/.github/workflows/resources.yaml
@@ -23,7 +23,7 @@ jobs:
         run: scalafix --check --syntactic --scala-version=3.3.0 shared jvm js native
       - name: Run Scalafmt
         run: |
-          ./millmill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources
+          ./mill mill.scalalib.scalafmt.ScalafmtModule/reformatAll __.sources
       - name: Stage changes
         run: git add .
       - name: Commit and push
@@ -44,9 +44,9 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Update all documentation files
-        run: ./milljvm.docs
+        run: ./mill jvm.docs
       - name: Update nanorc files for JLine
-        run: ./milljvm.nanorc
+        run: ./mill jvm.nanorc
       - name: Stage changes
         run: git add .
       - name: Commit and push

--- a/.github/workflows/send-message-to-versions.yaml
+++ b/.github/workflows/send-message-to-versions.yaml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v3*"
 
-env:
-  JAVA_OPTS: ${{ vars.JAVA_OPTS }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
           distribution: "adopt"
 
       - name: Scala to JS
-        run: ./mill --no-server js.fullLinkJS
+        run: ./milljs.fullLinkJS
 
       - name: Generate a token
         id: generate_token

--- a/.github/workflows/send-message-to-versions.yaml
+++ b/.github/workflows/send-message-to-versions.yaml
@@ -18,7 +18,7 @@ jobs:
           distribution: "adopt"
 
       - name: Scala to JS
-        run: ./milljs.fullLinkJS
+        run: ./mill js.fullLinkJS
 
       - name: Generate a token
         id: generate_token

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Test
-        run: ./milljvm.test
+        run: ./mill jvm.test
 
   native:
     name: Test Native
@@ -29,7 +29,7 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Test
-        run: ./millnative.test
+        run: ./mill native.test
 
   js:
     name: Compile JS
@@ -43,4 +43,4 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Compile
-        run: ./milljs.compile
+        run: ./mill js.compile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,6 @@ name: Test
 
 on: [push]
 
-env:
-  JAVA_OPTS: ${{ vars.JAVA_OPTS }}
-
 jobs:
   jvm:
     name: Test JVM
@@ -18,7 +15,7 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Test
-        run: ./mill --no-server jvm.test
+        run: ./milljvm.test
 
   native:
     name: Test Native
@@ -32,7 +29,7 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Test
-        run: ./mill --no-server native.test
+        run: ./millnative.test
 
   js:
     name: Compile JS
@@ -46,4 +43,4 @@ jobs:
           java-version: "17"
           distribution: "adopt"
       - name: Compile
-        run: ./mill --no-server js.compile
+        run: ./milljs.compile

--- a/shared/src/vyxal/parsing/Common.scala
+++ b/shared/src/vyxal/parsing/Common.scala
@@ -8,7 +8,7 @@ private[parsing] object Common:
   def eol[$: P]: P[Unit] = P("\n" | "\r\n" | "\r")
 
   given Whitespace with
-    def apply(implicit ctx: P[?]): P[Unit] = CharsWhileIn(" \t", 0)
+    def apply(implicit ctx: P[?]): P[Unit] = P(CharsWhileIn(" \t", 0))
 
   def int[$: P]: P[String] =
     P(("0" | (CharIn("1-9") ~~ CharsWhileIn("0-9", 0))).!)
@@ -16,7 +16,7 @@ private[parsing] object Common:
   def digits[$: P]: P[String] = P(CharsWhileIn("0-9").!)
 
   def varName[$: P]: P[String] =
-    (CharIn("A-Za-z_") ~~ CharsWhileIn("0-9A-Za-z_", 0)).?.!
+    P(CharIn("A-Za-z_") ~~ CharsWhileIn("0-9A-Za-z_", 0)).?.!
 
   def lambdaOpen[$: P]: P[String] = P(StringIn("λ", "ƛ", "Ω", "₳", "µ").!)
 

--- a/shared/src/vyxal/parsing/LiterateLexer.scala
+++ b/shared/src/vyxal/parsing/LiterateLexer.scala
@@ -241,6 +241,8 @@ private[parsing] object LiterateLexer:
         )
     }
 
+  def defineBlock[$: P]: P[LitToken] = P(defineModBlock | defineElemBlock)
+
   def extensionKeyword[$: P]: P[LitToken] =
     P(
       withRange("extension".!) ~ "(".? ~ withRange(word.filter(isLambdaParam)) ~
@@ -515,24 +517,26 @@ private[parsing] object LiterateLexer:
   /** This is split from singleToken to prevent stack overflows when Fastparse's
     * `|` macro is expanded
     */
-  def singleTokenSplit1[$: P]: P[LitToken] =
-    P(
-      lambdaBlock | extensionKeyword | unmodSymbol | defineObj |
-        defineModBlock | defineElemBlock | specialLambdaBlock | contextIndex |
-        functionCall | modifierSymbol | elementSymbol
-    )
+  def singleTokenSplit1[$: P]: P[LitToken] = ???
 
   def litVarToken[$: P]: P[LitToken] =
     P(litGetVariable | litSetVariable | litSetConstant | litAugVariable)
 
+  def litKeyword[$: P]: P[LitToken] =
+    P(
+      extensionKeyword | elementKeyword | negatedElementKeyword |
+        modifierKeyword | otherKeyword
+    )
+
+  def litStructToken[$: P]: P[LitToken] =
+    P(structOpener | litBranch | litStructClose)
+
   def singleToken[$: P]: P[LitToken] =
     P(
-      singleTokenSplit1 | litVarToken | elementKeyword | negatedElementKeyword |
-        tokenMove | modifierKeyword |
-        P(
-          structOpener | otherKeyword | litBranch | litStructClose | litNumber |
-            litString | normalGroup
-        )
+      lambdaBlock | litKeyword | unmodSymbol | defineObj | defineBlock |
+        specialLambdaBlock | contextIndex | functionCall | modifierSymbol |
+        elementSymbol | litVarToken | tokenMove | litStructToken | litNumber |
+        litString | normalGroup
     )
 
   def singleTokenGroup[$: P]: P[Seq[LitToken]] =

--- a/shared/src/vyxal/parsing/LiterateLexer.scala
+++ b/shared/src/vyxal/parsing/LiterateLexer.scala
@@ -531,7 +531,8 @@ private[parsing] object LiterateLexer:
         )
     )
 
-  def tokens[$: P]: P[List[LitToken]] = P(singleTokenGroup.rep).map(_.flatten.toList)
+  def tokens[$: P]: P[List[LitToken]] =
+    P(singleTokenGroup.rep).map(_.flatten.toList)
 
   def parseToken[$: P](
       tokenType: TokenType,

--- a/shared/src/vyxal/parsing/LiterateLexer.scala
+++ b/shared/src/vyxal/parsing/LiterateLexer.scala
@@ -167,7 +167,7 @@ private[parsing] object LiterateLexer:
 
   def defineModBlock[$: P]: P[LitToken] =
     P(
-      withRange("define".!) ~ withRange("*".!) ~
+      withRange("define".!) ~ withRange("*".!) ~/
         withRange(word.filter(isLambdaParam)) ~/ litBranch ~
         ( // Grab the first parameter branch
           withRange(",".! | word.filter(isLambdaParam)).rep ~ litBranch
@@ -210,7 +210,7 @@ private[parsing] object LiterateLexer:
 
   def defineElemBlock[$: P]: P[LitToken] =
     P(
-      withRange("define".!) ~ withRange("@".!) ~
+      withRange("define".!) ~ withRange("@".!) ~/
         withRange(word.filter(isLambdaParam)) ~/ litBranch ~
         ( // Grab the first parameter branch
           withRange(",".! | word.filter(isLambdaParam)).rep ~ litBranch

--- a/shared/src/vyxal/parsing/SBCSLexer.scala
+++ b/shared/src/vyxal/parsing/SBCSLexer.scala
@@ -194,15 +194,25 @@ private[parsing] object SBCSLexer:
   def comment[$: P]: P[Token] =
     parseToken(Comment, "##" ~~/ CharsWhile(c => c != '\n' && c != '\r').?.!)
 
+  def modifier[$: P]: P[Token] =
+    P(
+      monadicModifier | dyadicModifier | triadicModifier | tetradicModifier |
+        specialModifier
+    )
+
+  def structureToken[$: P]: P[Token] =
+    P(
+      structureOpen | structureSingleClose | structureAllClose | listOpen |
+        listClose
+    )
+
   def token[$: P]: P[Token] =
     P(
       comment | sugarTrigraph | unpackTrigraph | digraph | branch |
         defineExtension | modifierSymbol | defineObj | elementSymbol |
         originalSymbol | contextIndex | sbcsNumber | string | augVariable |
         getVariable | setVariable | setConstant | twoCharNumber |
-        twoCharString | singleCharString | monadicModifier | dyadicModifier |
-        triadicModifier | tetradicModifier | specialModifier | structureOpen |
-        structureSingleClose | structureAllClose | listOpen | listClose |
+        twoCharString | singleCharString | modifier | structureToken |
         newlines | command
     )
 

--- a/shared/src/vyxal/parsing/SBCSLexer.scala
+++ b/shared/src/vyxal/parsing/SBCSLexer.scala
@@ -206,14 +206,18 @@ private[parsing] object SBCSLexer:
         listClose
     )
 
+  def varToken[$: P]: P[Token] =
+    P(augVariable | getVariable | setVariable | setConstant)
+
+  def literal[$: P]: P[Token] =
+    P(sbcsNumber | string | twoCharNumber | twoCharString | singleCharString)
+
   def token[$: P]: P[Token] =
     P(
       comment | sugarTrigraph | unpackTrigraph | digraph | branch |
         defineExtension | modifierSymbol | defineObj | elementSymbol |
-        originalSymbol | contextIndex | sbcsNumber | string | augVariable |
-        getVariable | setVariable | setConstant | twoCharNumber |
-        twoCharString | singleCharString | modifier | structureToken |
-        newlines | command
+        originalSymbol | contextIndex | literal | varToken | modifier |
+        structureToken | newlines | command
     )
 
   def parseToken[$: P](


### PR DESCRIPTION
I think all the chained `|`s in `SBCSLexer.token` and `LiterateLexer.singleToken` were blowing the stack when compiling, because the macro for handling `|` involves a quote within a splice within a quote, and I couldn't find any other sources of a possible stack overflow (aside from `StringIn`, but all our usages of `StringIn` involve a small number of small strings, nothing to make a really deep trie)