### PR TITLE
Export lexing to the JavaScript module

### DIFF
--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -1,10 +1,14 @@
 package vyxal
 
-import vyxal.parsing.Lexer
+import vyxal.parsing.{ Lexer, Token }
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*
+
+class JSToken(val tokenType: String, val value: String, val startOffset: Int, val endOffset: Int) extends js.Object
+object JSToken:
+  def apply(token: Token) = new JSToken(token.tokenType.name(), token.value, token.range.startOffset, token.range.endOffset)
 
 /** To avoid loading Scopt with the JSVyxal object */
 @JSExportTopLevel("HelpText", moduleID = "helpText")
@@ -114,4 +118,10 @@ object JSVyxal:
 
   @JSExport
   def getVersion(): String = Interpreter.version
+
+  @JSExport
+  def lexSBCS(code: String): js.Array[JSToken] = js.Array(Lexer.lexSBCS(code).map(JSToken(_))*)
+
+  @JSExport
+  def lexLiterate(code: String): js.Array[JSToken] = js.Array(Lexer.lexLiterate(code).map(JSToken(_))*)
 end JSVyxal

--- a/js/src/vyxal/JSVyxal.scala
+++ b/js/src/vyxal/JSVyxal.scala
@@ -1,14 +1,25 @@
 package vyxal
 
-import vyxal.parsing.{ Lexer, Token }
+import vyxal.parsing.{Lexer, Token}
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.scalajs.js.JSConverters.*
 
-class JSToken(val tokenType: String, val value: String, val startOffset: Int, val endOffset: Int) extends js.Object
+class JSToken(
+    val tokenType: String,
+    val value: String,
+    val startOffset: Int,
+    val endOffset: Int,
+) extends js.Object
 object JSToken:
-  def apply(token: Token) = new JSToken(token.tokenType.name(), token.value, token.range.startOffset, token.range.endOffset)
+  def apply(token: Token) =
+    new JSToken(
+      token.tokenType.name(),
+      token.value,
+      token.range.startOffset,
+      token.range.endOffset,
+    )
 
 /** To avoid loading Scopt with the JSVyxal object */
 @JSExportTopLevel("HelpText", moduleID = "helpText")
@@ -120,8 +131,10 @@ object JSVyxal:
   def getVersion(): String = Interpreter.version
 
   @JSExport
-  def lexSBCS(code: String): js.Array[JSToken] = js.Array(Lexer.lexSBCS(code).map(JSToken(_))*)
+  def lexSBCS(code: String): js.Array[JSToken] =
+    js.Array(Lexer.lexSBCS(code).map(JSToken(_))*)
 
   @JSExport
-  def lexLiterate(code: String): js.Array[JSToken] = js.Array(Lexer.lexLiterate(code).map(JSToken(_))*)
+  def lexLiterate(code: String): js.Array[JSToken] =
+    js.Array(Lexer.lexLiterate(code).map(JSToken(_))*)
 end JSVyxal

--- a/shared/src/vyxal/parsing/Lexer.scala
+++ b/shared/src/vyxal/parsing/Lexer.scala
@@ -67,7 +67,8 @@ object Range:
   /** A dummy Range (mainly for generated/desugared code) */
   val fake: Range = Range(-1, -1)
 
-enum TokenType(val canonicalSBCS: Option[String] = None) extends Enum[TokenType] derives CanEqual:
+enum TokenType(val canonicalSBCS: Option[String] = None) extends Enum[TokenType]
+    derives CanEqual:
   case Number
   case Str
   case StructureOpen

--- a/shared/src/vyxal/parsing/Lexer.scala
+++ b/shared/src/vyxal/parsing/Lexer.scala
@@ -67,7 +67,7 @@ object Range:
   /** A dummy Range (mainly for generated/desugared code) */
   val fake: Range = Range(-1, -1)
 
-enum TokenType(val canonicalSBCS: Option[String] = None) derives CanEqual:
+enum TokenType(val canonicalSBCS: Option[String] = None) extends Enum[TokenType] derives CanEqual:
   case Number
   case Str
   case StructureOpen


### PR DESCRIPTION
Because `Lexer`.`lexLiterate` turns `Token`.`value` into its SBCS counterpart, the exported `vyxal`/`Vyxal`.`lexLiterate` does the same. Original input can however be trivially reconstructed using the `startOffset` and `endOffset` properties on `JSToken`

<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
