### PR TITLE
Fix REPL stops printing after a print element is ran

### DIFF
--- a/jvm/src/vyxal/JvmRepl.scala
+++ b/jvm/src/vyxal/JvmRepl.scala
@@ -28,6 +28,7 @@ object JvmRepl extends Repl:
     while true do
       val code = StdIn.readLine("> ")
       if code == null then return
+      ctx.globals.printed = false
       try Interpreter.execute(code)
       catch case ex: VyxalException => scribe.error(ex.getMessage(using ctx))
 
@@ -76,6 +77,7 @@ object JvmRepl extends Repl:
     while true do
       try
         val code = lineReader.readLine("> ")
+        ctx.globals.printed = false
         Interpreter.execute(code)
       catch
         case _: UserInterruptException => return

--- a/native/src/vyxal/NativeRepl.scala
+++ b/native/src/vyxal/NativeRepl.scala
@@ -3,9 +3,8 @@ package vyxal
 import scala.io.StdIn
 
 object NativeRepl extends Repl:
-  override def startRepl(fancy: Boolean)(using Context): Unit =
+  override def startRepl(fancy: Boolean)(using ctx: Context): Unit =
     while true do
-      print("> ")
-
-      val code = StdIn.readLine()
+      val code = StdIn.readLine("> ")
+      ctx.globals.printed = false
       Interpreter.execute(code)


### PR DESCRIPTION
This fixes a bug where after executing a print element in a REPL, all the next input lines don't get the automatically-print-the-top-of-the-stack behavior.

<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
