### PR TITLE
Fix `toVyxal` on `GetVar` and `SetVar` having wrong syntax

### DIFF
--- a/shared/src/vyxal/AST.scala
+++ b/shared/src/vyxal/AST.scala
@@ -168,8 +168,8 @@ enum AST(val arity: Option[Int]) derives CanEqual:
               case None => ""
           }${body.map(_.toVyxal).mkString("|")}}"
       case FnDef(name, lam, _) => ???
-      case GetVar(name, _) => s"#<$name"
-      case SetVar(name, _) => s"#>$name"
+      case GetVar(name, _) => s"#$$$name"
+      case SetVar(name, _) => s"#=$name"
       case Parameter(name) => s"$name,"
       case ast => ast.toString
 end AST


### PR DESCRIPTION
<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
