### PR TITLE
Only run test workflow on push, not pull_request

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
 
 jobs:
   jvm:


### PR DESCRIPTION
<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->

Currently, for pull requests, it runs twice. We can instead just have it run on pushes to any branch.