### PR TITLE
Fix bug where backslash couldn't occur in compressed strings

### DIFF
--- a/shared/src/vyxal/parsing/Lexer.scala
+++ b/shared/src/vyxal/parsing/Lexer.scala
@@ -325,7 +325,10 @@ abstract class LexerCommon:
     pop() // Pop the opening quote
 
     while programStack.nonEmpty && !headIn("\"„”“") do
-      if headEqual("\\") then stringVal ++= pop(2)
+      if headEqual("\\") then
+        val backslash = pop()
+        if headIn("„”“") then stringVal ++= backslash
+        else stringVal ++= backslash + pop()
       else stringVal ++= pop()
 
     var text =


### PR DESCRIPTION
<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
