### PR TITLE
document string-repeat concatenate "overload" for dot-product

### DIFF
--- a/shared/src/vyxal/elements/ElementInformation.scala
+++ b/shared/src/vyxal/elements/ElementInformation.scala
@@ -2412,6 +2412,11 @@ object ElementInformation:
         description = "Dot product of #1 and #2",
       ),
       Overload(
+        name = "String-repeat concatenate",
+        args = Seq("lst[num]", "lst[str]"),
+        description = "Repeat each string in #2 #1[i] times, then concatenate the result",
+      ),
+      Overload(
         name = "Bijective Base Conversion",
         args = Seq("num", "num"),
         description = " Convert #1 to bijective base #2",

--- a/shared/src/vyxal/elements/ElementInformation.scala
+++ b/shared/src/vyxal/elements/ElementInformation.scala
@@ -2414,7 +2414,8 @@ object ElementInformation:
       Overload(
         name = "String-repeat concatenate",
         args = Seq("lst[num]", "lst[str]"),
-        description = "Repeat each string in #2 #1[i] times, then concatenate the result",
+        description =
+          "Repeat each string in #2 #1[i] times, then concatenate the result",
       ),
       Overload(
         name = "Bijective Base Conversion",


### PR DESCRIPTION
i'm aware this is not an overload, simply a consequence of  the impl of dot-product. it's still a useful construct.

<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
