### PR TITLE
Round to arbitrary number of decimal places

### DIFF
--- a/shared/src/vyxal/elements/ElementInformation.scala
+++ b/shared/src/vyxal/elements/ElementInformation.scala
@@ -2885,7 +2885,7 @@ object ElementInformation:
         name = "Round to N places",
         args = Seq("num", "num"),
         description =
-          "Round #1 to #2 decimal places. Negative values of #2 will round to that power of 10",
+          "Round #1 to #2 decimal places. Negative values of #2 will round to that power of 10. Returns the string representation if #2 > 9",
       ),
       Overload(
         name = "Regex Full Match?",

--- a/shared/src/vyxal/elements/Elements.scala
+++ b/shared/src/vyxal/elements/Elements.scala
@@ -1241,7 +1241,8 @@ object Elements:
       case (a: VNum, b: VNum) =>
         if b == VNum(0) then NumberHelpers.round(a)
         else if b.toInt <= 9 then a - (a % (10 ** -(b.toInt)))
-          else NumberHelpers.round((a * (10**b.toInt))).toString().patch(NumberHelpers.log(a,10).toInt +1, ".", 0) //fallback to return the string representation if the precision is too high
+          else if a == VNum(0) then a else
+            NumberHelpers.round((a * (10**b.toInt))).toString().patch(NumberHelpers.round(NumberHelpers.log(a,10) + 0.5).toInt, ".", 0) //fallback to return the string representation if the precision is too high
       case (VStr(a), VStr(b)) => StringHelpers.r(b).matches(a)
     },
     addPart("℗", Monad, true) {

--- a/shared/src/vyxal/elements/Elements.scala
+++ b/shared/src/vyxal/elements/Elements.scala
@@ -1241,8 +1241,16 @@ object Elements:
       case (a: VNum, b: VNum) =>
         if b == VNum(0) then NumberHelpers.round(a)
         else if b.toInt <= 9 then a - (a % (10 ** -(b.toInt)))
-          else if a == VNum(0) then a else
-            NumberHelpers.round((a * (10**b.toInt))).toString().patch(NumberHelpers.round(NumberHelpers.log(a,10) + 0.5).toInt, ".", 0) //fallback to return the string representation if the precision is too high
+        else if a == VNum(0) then a
+        else
+          NumberHelpers
+            .round((a * (10 ** b.toInt)))
+            .toString()
+            .patch(
+              NumberHelpers.round(NumberHelpers.log(a, 10) + 0.5).toInt,
+              ".",
+              0,
+            ) // fallback to return the string representation if the precision is too high
       case (VStr(a), VStr(b)) => StringHelpers.r(b).matches(a)
     },
     addPart("℗", Monad, true) {

--- a/shared/src/vyxal/elements/Elements.scala
+++ b/shared/src/vyxal/elements/Elements.scala
@@ -1240,7 +1240,8 @@ object Elements:
       case (a: VList, b: VList) => ListHelpers.matrixMultiply(a, b)
       case (a: VNum, b: VNum) =>
         if b == VNum(0) then NumberHelpers.round(a)
-        else a - (a % (10 ** -(b.toInt)))
+        else if b.toInt <= 9 then a - (a % (10 ** -(b.toInt)))
+          else NumberHelpers.round((a * (10**b.toInt))).toString().patch(NumberHelpers.log(a,10).toInt +1, ".", 0) //fallback to return the string representation if the precision is too high
       case (VStr(a), VStr(b)) => StringHelpers.r(b).matches(a)
     },
     addPart("℗", Monad, true) {


### PR DESCRIPTION
ℳ can round to decimal places, but always returns 0 if #2 >9. this creates a fallback where the string representation of #1 will be returned instead, helping for challenges such as "print 1000 digits of pi"

<img width="1428" height="387" alt="image" src="https://github.com/user-attachments/assets/c2c9a019-25c3-4dda-b911-4607b5403edf" />


<!--
Vyxal Bot is capable of automatically labeling PRs! Just add "Closes #xyz" or similar as normal, and relevant tags will be added to the PR.
The bot will also label PRs based off of the head branch name (specifically branches starting with "v2-" or "v3-").
-->
